### PR TITLE
Fix memory allocation in unit tests. Relay Register/Key to separate header 

### DIFF
--- a/src/include/cdll.h
+++ b/src/include/cdll.h
@@ -4,22 +4,14 @@
  * @date 6 Jan 2020
  * @brief Header file for Circular Doubly Linked List module.
  *
- * Defines the constant MAX number of elements, the structs Key, Register
- * and CircularDoublyLinkedList and the prototypes for the subroutines of the
- * CircularDoublyLinkedList module.
+ * Defines the the CircularDoublyLinkedList and the prototypes for the
+ * routines of the CircularDoublyLinkedList module.
  */
 #ifndef CDLL_H
 #define CDLL_H
 
 #include <stddef.h>
-
-typedef int Key;
-
-typedef struct
-{
-  Key key; /* Key that maps the register */
-}
-Register;
+#include <register.h>
 
 typedef struct CircularDoublyLinkedList
 {

--- a/src/include/csll.h
+++ b/src/include/csll.h
@@ -4,22 +4,14 @@
  * @date 9 Jan 2020
  * @brief Header file for Circular Singly Linked List module.
  *
- * Defines the constant MAX number of elements, the structs Key, Register
- * and DoublyLinkedList and the prototypes for the subroutines of the
- * CircularSinglyLinkedList module.
+ * Defines the structDoublyLinkedList and the prototypes for the routines of
+ * the CircularSinglyLinkedList module.
  */
 #ifndef CSLL_H
 #define CSLL_H
 
 #include <stddef.h>
-
-typedef int Key;
-
-typedef struct
-{
-  Key key; /* Key that maps the register */
-}
-Register;
+#include <register.h>
 
 typedef struct CircularSinglyLinkedList
 {

--- a/src/include/dll.h
+++ b/src/include/dll.h
@@ -4,23 +4,15 @@
  * @date 2 Jan 2020
  * @brief Header file for Doubly Linked List module.
  *
- * Defines the constant MAX number of elements, the structs Key, Register
- * and DoublyLinkedList and the prototypes for the subroutines of the
- * DoublyLinkedList module.
+ * Defines the struct DoublyLinkedList and the prototypes for the routines of
+ * the DoublyLinkedList module.
  */
 #ifndef DLL_H
 #define DLL_H
 
 #include <stddef.h>
 #include <stdbool.h>
-
-typedef int Key;
-
-typedef struct
-{
-  Key key; /* Key that maps the register */
-}
-Register;
+#include <register.h>
 
 typedef struct DoublyLinkedList
 {
@@ -30,37 +22,37 @@ typedef struct DoublyLinkedList
 }
 DoublyLinkedList;
 
-/** @brief Inserts node at front of Linked List.
+/** @brief Inserts node at front of Doubly Linked List.
  *  
- * Inserts node at front of Linked List. If other nodes already exist in list
- * new node becomes new head and existing nodes are linked to new one. Returns
- * pointer to added node and updates double pointer with new head of the
- * linked list.
+ * Inserts node at front of Doubly Linked List. If other nodes already exist
+ * in list new node becomes new head and existing nodes are linked to new one.
+ * Returns pointer to added node and updates double pointer with new head of
+ * the linked list.
  *
- * @param head Double pointer to head of linked list. 
+ * @param head Double pointer to head of Doubly Linked List. 
  * @param k Key for Register of inserted node.
  * @return Pointer to inserted node.
  */
 DoublyLinkedList* dll_insert(DoublyLinkedList** head, Key k);
 
-/** @brief Retrieves node from linked list via key. 
+/** @brief Retrieves node from Doubly Linked List via key. 
  *
- * Iterates sequentially over linked list. If node with given key exists
+ * Iterates sequentially over Doubly Linked List. If node with given key exists
  * returns pointer to it, otherwise returns @c NULL.
  *
- * @param head Double pointer to head of linked list. 
+ * @param head Double pointer to head of Doubly Linked List. 
  * @param k Key for Register of inserted node.
  * @return Pointer to retrieved node.
  */
 DoublyLinkedList* dll_search(DoublyLinkedList** head, Key k);
 
-/** @brief Deletes given node from linked list. 
+/** @brief Deletes given node from Doubly Linked List. 
  *
- * Removes a node given via pointer from linked list. List is amended to make
- * up for absence of removed node. Allocated memory for node pointer is not
- * freed. It's up to the user to free memory allocated to pointer.
+ * Removes a node given via pointer from Doubly Linked List. List is amended
+ * to make up for absence of removed node. Allocated memory for node pointer
+ * is not freed. It's up to the user to free memory allocated to pointer.
  *
- * @param head Double pointer to head of linked list. 
+ * @param head Double pointer to head of Doubly Linked List. 
  * @param to_remove Pointer to node to be removed.
  * @return Void
  */

--- a/src/include/queue.h
+++ b/src/include/queue.h
@@ -1,26 +1,19 @@
 /**
-* @file queue.h
-* @author Benardi Nunes <benardinunes@gmail.com>
-* @date 2 Jan 2020
-* @brief Header file for Queue module.
-* 
-* Defines the constant MAX number of elements, the structs Key, Register 
-* and Queue and the prototypes for the subroutines of the Queue module.
-*/
+ * @file queue.h
+ * @author Benardi Nunes <benardinunes@gmail.com>
+ * @date 2 Jan 2020
+ * @brief Header file for Queue module.
+ * 
+ * Defines the constant MAX number of elements, the struct Queue and the
+ * prototypes for the routines of the Queue module.
+ */
 #ifndef QUEUE_H
 #define QUEUE_H
 
 #include <stdbool.h>
+#include <register.h>
 
 #define MAX 20
-
-typedef int Key;
-
-typedef struct
-{
-  Key key; /* Key that maps the register */
-}
-Register;
 
 typedef struct
 {
@@ -31,64 +24,57 @@ typedef struct
 Queue;
 
 /** @brief Initializes Queue to have 0 elements.
-*
-* Sets the attribute head and tail to 0. Existing
-* elements are ignored.
-*
-* @param q Queue as a pointer
-* @return Void
-*/
+ *
+ * Sets the attribute head and tail to 0. Existing elements are ignored.
+ *
+ * @param q Pointer to Queue
+ * @return Void
+ */
 void init_queue(Queue* q);
 
 /** @brief Checks whether the queue is empty. 
-*
-* If any element has been added to the queue 
-* returns true. If no element has been added 
-* or the queue has just been initialized returns
-* false. 
-*
-* @param q Queue as a pointer 
-* @return Whether queue is empty
-*/
+ *
+ * If any element has been added to the queue returns true. If no element has
+ * been added or the queue has just been initialized returns false. 
+ *
+ * @param q Pointer to Queue
+ * @return Whether queue is empty
+ */
 bool queue_empty(Queue* q);
 
 /** @brief Checks whether the queue is full. 
-*
-* If all available positions are occupied returns
-* true. A queue can hold n - 1 elements, so if 
-* MAX - 1 elements have been enqueued the queue is
-* full. If there's at least one available position
-* besides the one reserved to the tail or the queue
-* has just been initialized returns false. 
-*
-* @param q Queue as a pointer 
-* @return Whether queue is empty
-*/
+ *
+ * If all available positions are occupied returns true. A queue can
+ * hold n - 1 elements, so if MAX - 1 elements have been enqueued the queue is
+ * full. If there's at least one available position besides the one reserved
+ * to the tail or the queue has just been initialized returns false. 
+ *
+ * @param q Queue as a pointer 
+ * @return Whether queue is empty
+ */
 bool queue_full(Queue* q);
 
 /** @brief Adds element to tail of queue. 
-*
-* If there's an available position plus the 
-* position reserved for the tail of the queue
-* adds element to tail of queue and returns true.
-* Else doesn't change queue and returns false. 
-*
-* @param q Queue as a pointer 
-* @return Whether element could be enqueued
-*/
+ *
+ * If there's an available position plus the position reserved for the tail of
+ * the queue adds element to tail of queue and returns true. Else doesn't
+ * change queue and returns false. 
+ *
+ * @param q Queue as a pointer 
+ * @return Whether element could be enqueued
+ */
 bool enqueue(Queue* q, Register reg);
 
 /** @brief Removes head of queue and returns it. 
-*
-* If there's at least one element in queue removes
-* head of queue, puts its value into given pointer
-* and returns true. Otherwise doesn't update pointer
-* and returns false. 
-*
-* @param q Queue as a pointer 
-* @param removed Pointer to hold value of removed element
-* @return Whether an element could be dequeued
-*/
+ *
+ * If there's at least one element in queue removes head of queue, puts its
+ * value into given pointer and returns true. Otherwise doesn't update pointer
+ * and returns false. 
+ *
+ * @param q Queue as a pointer 
+ * @param removed Pointer to hold value of removed element
+ * @return Whether an element could be dequeued
+ */
 bool dequeue(Queue* q, Register* removed);
 
 #endif

--- a/src/include/register.h
+++ b/src/include/register.h
@@ -1,0 +1,20 @@
+/**
+ * @file register.h
+ * @author Benardi Nunes <benardinunes@gmail.com>
+ * @date 10 Jan 2020
+ * @brief Header file for Register and Key.
+ *
+ * Defines the structs Key and Register.
+ */
+#ifndef REGISTER_H
+#define REGISTER_H
+
+typedef int Key;
+
+typedef struct
+{
+  Key key; /* Key that maps the register */
+}
+Register;
+
+#endif

--- a/src/include/seq_list.h
+++ b/src/include/seq_list.h
@@ -4,23 +4,17 @@
  * @date 12 Oct 2019
  * @brief Header file for Sequential List module.
  *
- * Defines the constant MAX number of elements, the structs Key, Register 
- * and SeqList and the prototypes for the subroutines of the Sequential 
- * List module.
+ * Defines the constant MAX number of elements, the struct SeqList and the
+ * prototypes for the routines of the Sequential List module.
  */
 #ifndef SEQ_LIST_H
 #define SEQ_LIST_H
 
 #include <stdbool.h>
+#include <register.h>
 
 #define MAX 20
 
-typedef int Key;
-typedef struct
-{
-  Key key; /* Key that maps the register */
-}
-Register;
 typedef struct
 {
   Register A[MAX + 1]; /* Array that stores the elements */
@@ -30,8 +24,7 @@ SeqList;
 
 /** @brief Initializes Sequential List with 0 elements.
  *
- * Sets the attribute nElems of a Sequential List given
- * as a pointer to 0.
+ * Sets the attribute nElems of a Sequential List given as a pointer to 0.
  *
  * @param sl Sequential List as pointer
  * @return Void
@@ -40,8 +33,8 @@ void init_seq_list(SeqList* sl);
 
 /** @brief Reinitializes Sequential List with 0 elements.
  *
- * Sets the attribute nElems of a Sequential List (that has
- * been used before) given as a pointer to 0.
+ * Sets the attribute nElems of a Sequential List (that has been used before)
+ * given as a pointer to 0.
  *
  * @param sl Sequential List as pointer
  * @return Void
@@ -50,35 +43,32 @@ void reinit_seq_list(SeqList* sl);
 
 /** @brief Calculates the size of a Sequential List.
  *
- * Calculates the size of a initialized Sequential List, 
- * undefined behavior if not properly initialized
+ * Calculates the size of a initialized Sequential List, undefined behavior if
+ * not properly initialized
  *
  * @param sl Sequential List as pointer
  * @return The size of the Sequential List
  */
 int size(SeqList* sl);
 
-/** @brief Inserts register in Sequential List at given
- *         position. 
+/** @brief Inserts register in Sequential List at given position. 
  *
- * If given position is invalid (bigger than MAX/nElems
- * or less than zero) the Sequential List is 
- * kept unchanged and false is returned. Else, the element
+ * If given position is invalid (bigger than MAX/nElems or less than zero) the
+ * Sequential List is kept unchanged and false is returned. Else, the element
  * is inserted and true returned.
  *
- * @param sl Sequential List as a pointer. 
+ * @param sl Pointer to Sequential List. 
  * @param reg Element that contains key.
  * @param i Position where to insert 
  * @return Whether element could be inserted
  */
 bool insert_elem(SeqList* sl, Register reg, int i);
 
-/** @brief Inserts register in Sequential List whilst
- *         ensuring the List stays sorted. 
+/** @brief Inserts register in Sequential List whilst ensuring the List stays
+ * sorted. 
  *
- * If the Sequential List is already filled up it is   
- * kept unchanged and false is returned. Else, the element
- * is inserted and true returned.
+ * If the Sequential List is already filled up it is kept unchanged and false
+ * is returned. Else, the element is inserted and true returned.
  *
  * @param sl Sequential List as pointer
  * @param reg Element that contains key
@@ -86,12 +76,11 @@ bool insert_elem(SeqList* sl, Register reg, int i);
  */
 bool insert_sorted(SeqList* sl, Register reg);
 
-/** @brief Sequentially searchs a Sequential List and
- *         returns index of first occurrence.
+/** @brief Sequentially searchs a Sequential List and returns
+ * index of first occurrence.
  *
- * Sequentially iterates over Sequential List in
- * ascending order of index. Returns index of first
- * occurrence that matches given Register key, else
+ * Sequentially iterates over Sequential List in ascending order of index.
+ * Returns index of first occurrence that matches given Register key, else
  * returns -1. 
  * 
  * @param sl Sequential List as pointer
@@ -100,12 +89,11 @@ bool insert_sorted(SeqList* sl, Register reg);
  */
 int seq_search(SeqList* sl, Key k);
 
-/** @brief Performs binary search on a Sequential List
- *         under the assumption it is sorted.
+/** @brief Performs binary search on a Sequential List under the assumption it
+ * is sorted.
  *
- * Performs binary search on a sorted Sequential List. 
- * Returns index of first matched occurrence of given
- * Register key, else returns -1. 
+ * Performs binary search on a sorted Sequential List. Returns index of first
+ * matched occurrence of given Register key, else returns -1. 
  * 
  * @param sl Sequential List as pointer
  * @param k Key to be found
@@ -113,14 +101,12 @@ int seq_search(SeqList* sl, Key k);
  */
 int binary_search(SeqList* sl, Key k);
 
-/** @brief Sequentially searchs a Sequential List and
- *         returns index of first occurrence.
+/** @brief Sequentially searchs a Sequential List and returns index of first
+ * occurrence.
  * 
- * Sequentially iterates over Sequential List in
- * ascending order of index. Sentinel is appended to
- * List to allow a more efficient search. Returns 
- * index of first occurrence that matches given 
- * Register key, else returns -1. 
+ * Sequentially iterates over Sequential List in ascending order of index.
+ * Sentinel is appended to List to allow a more efficient search. Returns 
+ * index of first occurrence that matches given Register key, else returns -1. 
  * 
  * @param sl Sequential List as pointer
  * @param k Key to be found
@@ -128,14 +114,13 @@ int binary_search(SeqList* sl, Key k);
  */
 int sentinel_search(SeqList* sl, Key k);
 
-/** @brief Sequentially searchs a Sequential List and
- *         removes first occurrence.
+/** @brief Sequentially searchs a Sequential List and removes first
+ * occurrence.
  *
- * Sequentially iterates over Sequential List in
- * ascending order of index. Removes first occurrence
- * that matches given Register key and shifts remaining
- * elements to the right to keep Sequential List 
- * contiguous. Else, keeps Sequential List untouched. 
+ * Sequentially iterates over Sequential List in ascending order of index.
+ * Removes first occurrence that matches given Register key and shifts
+ * remaining elements to the right to keep Sequential List contiguous.
+ * Else, keeps Sequential List untouched. 
  *
  * @param k Key to be found
  * @param sl Sequential List as pointer
@@ -145,13 +130,12 @@ bool remove_elem(Key key, SeqList* sl);
 
 /** @brief Prints elements in Sequential List
  *
- * Sequentially iterates over Sequential List in
- * ascending order of index, printing the key of
- * each existing element separated by a blank space.  
+ * Sequentially iterates over Sequential List in ascending order of index,
+ * printing the key of each existing element separated by a blank space.  
  * 
  * @param sl Sequential List as pointer
  * @return Void
  */
 void show_list(SeqList* sl);
 
-#endif /* SEQ_LIST_H */
+#endif

--- a/src/include/sll.h
+++ b/src/include/sll.h
@@ -4,22 +4,14 @@
  * @date 7 Jan 2020
  * @brief Header file for Singly Linked List module.
  *
- * Defines the constant MAX number of elements, the structs Key, Register
- * and SinglyLinkedList and the prototypes for the subroutines of the
- * SinglyLinkedList module.
+ * Defines the constant MAX number of elements, the struct SinglyLinkedList
+ * and the prototypes for the routines of the SinglyLinkedList module.
  */
 #ifndef SLL_H
 #define SLL_H
 
 #include <stddef.h>
-
-typedef int Key;
-
-typedef struct
-{
-  Key key; /* Key that maps the register */
-}
-Register;
+#include <register.h>
 
 typedef struct SinglyLinkedList
 {

--- a/src/include/stack.h
+++ b/src/include/stack.h
@@ -4,23 +4,16 @@
  * @date 1 Jan 2020
  * @brief Header file for Stack module.
  * 
- * Defines the constant MAX number of elements, the structs Key, Register 
- * and Stack and the prototypes for the subroutines of the Stack module.
+ * Defines the constant MAX number of elements, the struct Stack and the
+ * prototypes for the subroutines of the Stack module.
  */
 #ifndef STACK_H
 #define STACK_H
 
 #include <stdbool.h>
+#include <register.h>
 
 #define MAX 20
-
-typedef int Key;
-
-typedef struct
-{
-  Key key; /* Key that maps the register*/
-}
-Register;
 
 typedef struct
 {
@@ -31,59 +24,54 @@ Stack;
 
 /** @brief Initializes Stack to have 0 elements.
  *
- * Sets the attribute top to -1. Existing elements are
- * ignored.
+ * Sets the attribute top to -1. Existing elements are ignored.
  *
- * @param stk Stack as a pointer
+ * @param stk Pointer to Stack
  * @return Void
  */
 void init_stack(Stack* stk);
 
 /** @brief Checks whether the stack is empty. 
  *
- * If any element has been added to the stack 
- * returns true. If no element has been added 
- * or the stack has just been initialized returns
- * false. 
+ * If any element has been added to the stack returns true. If no element has
+ * been added or the stack has just been initialized returns false. 
  *
- * @param stk Stack as a pointer 
+ * @param stk Pointer to Stack 
  * @return Whether stack is empty
  */
 bool stack_empty(Stack* stk);
 
 /** @brief Checks whether the stack is full. 
  *
- * If all available positions are occupied returns
- * true. If there's at least one available position 
- * or the stack has just been initialized returns
+ * If all available positions are occupied returns true. If there's at least
+ * one available position or the stack has just been initialized returns
  * false. 
  *
- * @param stk Stack as a pointer 
+ * @param stk Pointer to Stack 
  * @return Whether stack is empty
  */
 bool stack_full(Stack* stk);
 
 /** @brief Pushes element on top of stack. 
  *
- * If there's an available position pushes 
- * element on top of stack and returns true.
- * Else does not change stack and returns false. 
+ * If there's an available position pushes element on top of stack and returns
+ * true. Else does not change stack and returns false. 
  * 
- * @param stk Stack as a pointer 
+ * @param stk Pointer to Stack 
  * @return Whether element could be pushed
  */
 bool push(Stack* stk, Register reg);
 
 /** @brief Removes element from stack and returns it. 
  *
- * If there's at least one element in stack removes it,
- * puts its value into given pointer and returns true.
- * Otherwise doesn't update pointer and returns false. 
+ * If there's at least one element in stack removes it, puts its value into
+ * given pointer and returns true. Otherwise doesn't update pointer and
+ * returns false. 
  *
- * @param stk Stack as a pointer 
+ * @param stk Pointer to Stack 
  * @param removed Pointer to hold value of removed element
  * @return Whether an element could be popped
  */
 bool pop(Stack* stk, Register* removed);
 
-#endif /* STACK_H */
+#endif

--- a/tests/test_cdll.c
+++ b/tests/test_cdll.c
@@ -144,7 +144,6 @@ START_TEST(test_cdll_search_1)
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
     node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    retrieved = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -178,7 +177,6 @@ START_TEST(test_cdll_search_2)
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
     node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    retrieved = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -212,7 +210,6 @@ START_TEST(test_cdll_search_3)
     nil = malloc(sizeof(CircularDoublyLinkedList*));
     node1 = malloc(sizeof(CircularDoublyLinkedList*));
     node2 = malloc(sizeof(CircularDoublyLinkedList*));
-    retrieved = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -261,7 +258,6 @@ START_TEST(test_cdll_search_4)
     nil = malloc(sizeof(CircularDoublyLinkedList*));
     node1 = malloc(sizeof(CircularDoublyLinkedList*));
     node2 = malloc(sizeof(CircularDoublyLinkedList*));
-    retrieved = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -311,7 +307,6 @@ START_TEST(test_cdll_search_5)
     nil = malloc(sizeof(CircularDoublyLinkedList*));
     node1 = malloc(sizeof(CircularDoublyLinkedList*));
     node2 = malloc(sizeof(CircularDoublyLinkedList*));
-    retrieved = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -366,7 +361,6 @@ START_TEST(test_cdll_search_6)
     node1 = malloc(sizeof(CircularDoublyLinkedList*));
     node2 = malloc(sizeof(CircularDoublyLinkedList*));
     node3 = malloc(sizeof(CircularDoublyLinkedList*));
-    retrieved = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -426,7 +420,6 @@ START_TEST(test_cdll_search_7)
     node1 = malloc(sizeof(CircularDoublyLinkedList*));
     node2 = malloc(sizeof(CircularDoublyLinkedList*));
     node3 = malloc(sizeof(CircularDoublyLinkedList*));
-    retrieved = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -492,7 +485,6 @@ START_TEST(test_cdll_search_8)
     node1 = malloc(sizeof(CircularDoublyLinkedList*));
     node2 = malloc(sizeof(CircularDoublyLinkedList*));
     node3 = malloc(sizeof(CircularDoublyLinkedList*));
-    retrieved = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);

--- a/tests/test_cdll.c
+++ b/tests/test_cdll.c
@@ -28,7 +28,6 @@ START_TEST(test_cdll_insert_1)
     CircularDoublyLinkedList* node1;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -54,8 +53,6 @@ START_TEST(test_cdll_insert_2)
     CircularDoublyLinkedList* node2;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -94,9 +91,6 @@ START_TEST(test_cdll_insert_3)
     CircularDoublyLinkedList* node3;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
-    node3 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -143,7 +137,6 @@ START_TEST(test_cdll_search_1)
     CircularDoublyLinkedList* retrieved;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -176,7 +169,6 @@ START_TEST(test_cdll_search_2)
     CircularDoublyLinkedList* retrieved;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -208,8 +200,6 @@ START_TEST(test_cdll_search_3)
     CircularDoublyLinkedList* retrieved;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -256,8 +246,6 @@ START_TEST(test_cdll_search_4)
     CircularDoublyLinkedList* retrieved;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -305,8 +293,6 @@ START_TEST(test_cdll_search_5)
     CircularDoublyLinkedList* retrieved;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -358,9 +344,6 @@ START_TEST(test_cdll_search_6)
     CircularDoublyLinkedList* retrieved;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
-    node3 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -417,9 +400,6 @@ START_TEST(test_cdll_search_7)
     CircularDoublyLinkedList* retrieved;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
-    node3 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -482,9 +462,6 @@ START_TEST(test_cdll_search_8)
     CircularDoublyLinkedList* retrieved;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
-    node3 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -539,7 +516,6 @@ START_TEST(test_cdll_delete_1)
     CircularDoublyLinkedList* node1;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -571,8 +547,6 @@ START_TEST(test_cdll_delete_2)
     CircularDoublyLinkedList* node2;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -625,8 +599,6 @@ START_TEST(test_cdll_delete_3)
     CircularDoublyLinkedList* node2;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -680,9 +652,6 @@ START_TEST(test_cdll_delete_4)
     CircularDoublyLinkedList* node3;
 
     nil = malloc(sizeof(CircularDoublyLinkedList*));
-    node1 = malloc(sizeof(CircularDoublyLinkedList*));
-    node2 = malloc(sizeof(CircularDoublyLinkedList*));
-    node3 = malloc(sizeof(CircularDoublyLinkedList*));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);

--- a/tests/test_csll.c
+++ b/tests/test_csll.c
@@ -286,7 +286,6 @@ START_TEST(test_csll_search_1)
     CircularSinglyLinkedList* retrieved;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    retrieved = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     retrieved = csll_search(tail, 10);
@@ -311,7 +310,6 @@ START_TEST(test_csll_search_2)
     node1 = malloc(sizeof(CircularSinglyLinkedList*));
     node2 = malloc(sizeof(CircularSinglyLinkedList*));
     node3 = malloc(sizeof(CircularSinglyLinkedList*));
-    retrieved = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -386,7 +384,6 @@ START_TEST(test_csll_search_3)
     node1 = malloc(sizeof(CircularSinglyLinkedList*));
     node2 = malloc(sizeof(CircularSinglyLinkedList*));
     node3 = malloc(sizeof(CircularSinglyLinkedList*));
-    retrieved = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -461,7 +458,6 @@ START_TEST(test_csll_search_4)
     node1 = malloc(sizeof(CircularSinglyLinkedList*));
     node2 = malloc(sizeof(CircularSinglyLinkedList*));
     node3 = malloc(sizeof(CircularSinglyLinkedList*));
-    retrieved = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -530,7 +526,6 @@ START_TEST(test_csll_search_5)
     node1 = malloc(sizeof(CircularSinglyLinkedList*));
     node2 = malloc(sizeof(CircularSinglyLinkedList*));
     node3 = malloc(sizeof(CircularSinglyLinkedList*));
-    retrieved = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -605,7 +600,6 @@ START_TEST(test_csll_search_6)
     node1 = malloc(sizeof(CircularSinglyLinkedList*));
     node2 = malloc(sizeof(CircularSinglyLinkedList*));
     node3 = malloc(sizeof(CircularSinglyLinkedList*));
-    retrieved = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -684,7 +678,6 @@ START_TEST(test_csll_search_7)
     node1 = malloc(sizeof(CircularSinglyLinkedList*));
     node2 = malloc(sizeof(CircularSinglyLinkedList*));
     node3 = malloc(sizeof(CircularSinglyLinkedList*));
-    retrieved = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -762,7 +755,6 @@ START_TEST(test_csll_search_8)
     node1 = malloc(sizeof(CircularSinglyLinkedList*));
     node2 = malloc(sizeof(CircularSinglyLinkedList*));
     node3 = malloc(sizeof(CircularSinglyLinkedList*));
-    retrieved = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -840,7 +832,6 @@ START_TEST(test_csll_search_9)
     node1 = malloc(sizeof(CircularSinglyLinkedList*));
     node2 = malloc(sizeof(CircularSinglyLinkedList*));
     node3 = malloc(sizeof(CircularSinglyLinkedList*));
-    retrieved = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);

--- a/tests/test_csll.c
+++ b/tests/test_csll.c
@@ -13,7 +13,6 @@ START_TEST(test_csll_insert_begin_1)
     CircularSinglyLinkedList* node1;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -41,8 +40,6 @@ START_TEST(test_csll_insert_begin_2)
     CircularSinglyLinkedList* node2;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -87,9 +84,6 @@ START_TEST(test_csll_insert_begin_3)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -148,7 +142,6 @@ START_TEST(test_csll_insert_end_1)
     CircularSinglyLinkedList* node1;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -176,8 +169,6 @@ START_TEST(test_csll_insert_end_2)
     CircularSinglyLinkedList* node2;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -223,9 +214,6 @@ START_TEST(test_csll_insert_end_3)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -307,9 +295,6 @@ START_TEST(test_csll_search_2)
     CircularSinglyLinkedList* retrieved;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -381,9 +366,6 @@ START_TEST(test_csll_search_3)
     CircularSinglyLinkedList* retrieved;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -455,9 +437,6 @@ START_TEST(test_csll_search_4)
     CircularSinglyLinkedList* retrieved;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -523,9 +502,6 @@ START_TEST(test_csll_search_5)
     CircularSinglyLinkedList* retrieved;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -597,9 +573,6 @@ START_TEST(test_csll_search_6)
     CircularSinglyLinkedList* retrieved;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -675,9 +648,6 @@ START_TEST(test_csll_search_7)
     CircularSinglyLinkedList* retrieved;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -752,9 +722,6 @@ START_TEST(test_csll_search_8)
     CircularSinglyLinkedList* retrieved;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -829,9 +796,6 @@ START_TEST(test_csll_search_9)
     CircularSinglyLinkedList* retrieved;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -896,7 +860,6 @@ START_TEST(test_csll_delete_1)
     CircularSinglyLinkedList* node1;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -928,7 +891,6 @@ START_TEST(test_csll_delete_2)
     CircularSinglyLinkedList* node1;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -962,9 +924,6 @@ START_TEST(test_csll_delete_3)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1052,9 +1011,6 @@ START_TEST(test_csll_delete_4)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1144,9 +1100,6 @@ START_TEST(test_csll_delete_5)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1225,9 +1178,6 @@ START_TEST(test_csll_delete_6)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1306,9 +1256,6 @@ START_TEST(test_csll_delete_7)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1387,9 +1334,6 @@ START_TEST(test_csll_delete_8)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1468,9 +1412,6 @@ START_TEST(test_csll_delete_9)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1538,9 +1479,6 @@ START_TEST(test_csll_delete_10)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1608,9 +1546,6 @@ START_TEST(test_csll_delete_11)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1678,9 +1613,6 @@ START_TEST(test_csll_delete_12)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1748,9 +1680,6 @@ START_TEST(test_csll_delete_13)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1818,9 +1747,6 @@ START_TEST(test_csll_insert_begin_end_1)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1881,9 +1807,6 @@ START_TEST(test_csll_insert_begin_end_2)
     CircularSinglyLinkedList* node3;
 
     tail = malloc(sizeof(CircularSinglyLinkedList**));
-    node1 = malloc(sizeof(CircularSinglyLinkedList*));
-    node2 = malloc(sizeof(CircularSinglyLinkedList*));
-    node3 = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -15,7 +15,6 @@ START_TEST(test_dll_insert_1)
     DoublyLinkedList** head;
 
     head = malloc(sizeof(DoublyLinkedList**));
-    node1 = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -150);
@@ -42,8 +41,6 @@ START_TEST(test_dll_insert_2)
     DoublyLinkedList** head;
 
     head = malloc(sizeof(DoublyLinkedList**));
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, 10);
@@ -86,10 +83,6 @@ START_TEST(test_dll_insert_3)
     DoublyLinkedList* node4;
     DoublyLinkedList** head;
 
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
-    node3 = malloc(sizeof(DoublyLinkedList*));
-    node4 = malloc(sizeof(DoublyLinkedList*));
     head = malloc(sizeof(DoublyLinkedList**));
 
     *head = NULL;
@@ -156,10 +149,6 @@ START_TEST(test_dll_search_1)
     DoublyLinkedList* node4;
     DoublyLinkedList** head;
 
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
-    node3 = malloc(sizeof(DoublyLinkedList*));
-    node4 = malloc(sizeof(DoublyLinkedList*));
     head = malloc(sizeof(DoublyLinkedList**));
 
     *head = NULL;
@@ -194,10 +183,6 @@ START_TEST(test_dll_search_2)
     DoublyLinkedList* node4;
     DoublyLinkedList** head;
 
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
-    node3 = malloc(sizeof(DoublyLinkedList*));
-    node4 = malloc(sizeof(DoublyLinkedList*));
     head = malloc(sizeof(DoublyLinkedList**));
 
     *head = NULL;
@@ -228,12 +213,6 @@ START_TEST(test_dll_search_3)
     DoublyLinkedList* node6;
     DoublyLinkedList** head;
 
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
-    node3 = malloc(sizeof(DoublyLinkedList*));
-    node4 = malloc(sizeof(DoublyLinkedList*));
-    node5 = malloc(sizeof(DoublyLinkedList*));
-    node6 = malloc(sizeof(DoublyLinkedList*));
     head = malloc(sizeof(DoublyLinkedList**));
 
     *head = NULL;
@@ -276,12 +255,6 @@ START_TEST(test_dll_search_4)
     DoublyLinkedList* node6;
     DoublyLinkedList** head;
 
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
-    node3 = malloc(sizeof(DoublyLinkedList*));
-    node4 = malloc(sizeof(DoublyLinkedList*));
-    node5 = malloc(sizeof(DoublyLinkedList*));
-    node6 = malloc(sizeof(DoublyLinkedList*));
     head = malloc(sizeof(DoublyLinkedList**));
 
     *head = NULL;
@@ -320,8 +293,6 @@ START_TEST(test_dll_delete_1)
     DoublyLinkedList** head;
 
     head = malloc(sizeof(DoublyLinkedList**));
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -365,8 +336,6 @@ START_TEST(test_dll_delete_2)
     DoublyLinkedList** head;
 
     head = malloc(sizeof(DoublyLinkedList**));
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -409,7 +378,6 @@ START_TEST(test_dll_delete_3)
     DoublyLinkedList** head;
 
     head = malloc(sizeof(DoublyLinkedList**));
-    node1 = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -443,9 +411,6 @@ START_TEST(test_dll_delete_4)
     DoublyLinkedList** head;
 
     head = malloc(sizeof(DoublyLinkedList**));
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
-    node3 = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, 25);
@@ -506,7 +471,6 @@ START_TEST(test_dll_delete_5)
     DoublyLinkedList** head;
 
     head = malloc(sizeof(DoublyLinkedList**));
-    node = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     dll_insert(head, 25);
@@ -540,8 +504,6 @@ START_TEST(test_dll_delete_6)
     DoublyLinkedList** head;
 
     head = malloc(sizeof(DoublyLinkedList**));
-    node1 = malloc(sizeof(DoublyLinkedList*));
-    node2 = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     dll_insert(head, 25);

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -5,22 +5,9 @@
 #include <stdbool.h>
 #include <dll.h>
 
-DoublyLinkedList* node;
 Register reg;
 
-void setup(void);
-void teardown(void);
 Suite *make_dll_suite(void);
-
-void setup(void)
-{
-    node = malloc(sizeof(DoublyLinkedList*));
-}
-
-void teardown(void)
-{
-    free(node);
-}
 
 START_TEST(test_dll_insert_1)
 {
@@ -42,6 +29,9 @@ START_TEST(test_dll_insert_1)
     ck_assert_int_eq((*head) == NULL, false);
     ck_assert_int_eq((*head)->prev == NULL, true);
     ck_assert_int_eq((*head)->next == NULL, true);
+
+    free(node1);
+    free(head);
 }
 END_TEST
 
@@ -81,6 +71,10 @@ START_TEST(test_dll_insert_2)
     ck_assert_int_eq(node2->next == NULL, false);
     ck_assert_int_eq(node2->data.key, 30);
     ck_assert_int_eq(node2->next->prev->data.key, 30);
+
+    free(node2);
+    free(node1);
+    free(head);
 }
 END_TEST
 
@@ -144,22 +138,35 @@ START_TEST(test_dll_insert_3)
     ck_assert_int_eq(node4->prev == NULL, true);
     ck_assert_int_eq(node4->next == NULL, false);
     ck_assert_int_eq(node4->next->data.key, -12);
+
+    free(node4);
+    free(node3);
+    free(node2);
+    free(node1);
+    free(head);
 }
 END_TEST
 
 START_TEST(test_dll_search_1)
 {
     DoublyLinkedList* retrieved;
+    DoublyLinkedList* node1;
+    DoublyLinkedList* node2;
+    DoublyLinkedList* node3;
+    DoublyLinkedList* node4;
     DoublyLinkedList** head;
 
-    retrieved = malloc(sizeof(DoublyLinkedList*));
+    node1 = malloc(sizeof(DoublyLinkedList*));
+    node2 = malloc(sizeof(DoublyLinkedList*));
+    node3 = malloc(sizeof(DoublyLinkedList*));
+    node4 = malloc(sizeof(DoublyLinkedList*));
     head = malloc(sizeof(DoublyLinkedList**));
 
     *head = NULL;
-    dll_insert(head, -67);
-    dll_insert(head, 30);
-    dll_insert(head, -12);
-    dll_insert(head, 0);
+    node1 = dll_insert(head, -67);
+    node2 = dll_insert(head, 30);
+    node3 = dll_insert(head, -12);
+    node4 = dll_insert(head, 0);
     retrieved = dll_search(head, 30);
 
     ck_assert_int_eq(retrieved == NULL, false);
@@ -170,46 +177,72 @@ START_TEST(test_dll_search_1)
     ck_assert_int_eq(retrieved->prev->data.key, -12);
     ck_assert_int_eq(retrieved->prev->prev->data.key, 0);
 
-    free(retrieved);
+    free(node4);
+    free(node3);
+    free(node2);
+    free(node1);
+    free(head);
 }
 END_TEST
 
 START_TEST(test_dll_search_2)
 {
     DoublyLinkedList* retrieved;
+    DoublyLinkedList* node1;
+    DoublyLinkedList* node2;
+    DoublyLinkedList* node3;
+    DoublyLinkedList* node4;
     DoublyLinkedList** head;
 
-    retrieved = malloc(sizeof(DoublyLinkedList*));
+    node1 = malloc(sizeof(DoublyLinkedList*));
+    node2 = malloc(sizeof(DoublyLinkedList*));
+    node3 = malloc(sizeof(DoublyLinkedList*));
+    node4 = malloc(sizeof(DoublyLinkedList*));
     head = malloc(sizeof(DoublyLinkedList**));
 
     *head = NULL;
-    dll_insert(head, 23);
-    dll_insert(head, 5);
-    dll_insert(head, -17);
-    dll_insert(head, -10);
+    node1 = dll_insert(head, 23);
+    node2 = dll_insert(head, 5);
+    node3 = dll_insert(head, -17);
+    node4 = dll_insert(head, -10);
     retrieved = dll_search(head, 25);
 
     ck_assert_int_eq(retrieved == NULL, true);
 
-    free(retrieved);
+    free(node4);
+    free(node3);
+    free(node2);
+    free(node1);
+    free(head);
 }
 END_TEST
 
 START_TEST(test_dll_search_3)
 {
     DoublyLinkedList* retrieved;
+    DoublyLinkedList* node1;
+    DoublyLinkedList* node2;
+    DoublyLinkedList* node3;
+    DoublyLinkedList* node4;
+    DoublyLinkedList* node5;
+    DoublyLinkedList* node6;
     DoublyLinkedList** head;
 
-    retrieved = malloc(sizeof(DoublyLinkedList*));
+    node1 = malloc(sizeof(DoublyLinkedList*));
+    node2 = malloc(sizeof(DoublyLinkedList*));
+    node3 = malloc(sizeof(DoublyLinkedList*));
+    node4 = malloc(sizeof(DoublyLinkedList*));
+    node5 = malloc(sizeof(DoublyLinkedList*));
+    node6 = malloc(sizeof(DoublyLinkedList*));
     head = malloc(sizeof(DoublyLinkedList**));
 
     *head = NULL;
-    dll_insert(head, -67);
-    dll_insert(head, 30);
-    dll_insert(head, -12);
-    dll_insert(head, 0);
-    dll_insert(head, 20);
-    dll_insert(head, -189);
+    node1 = dll_insert(head, -67);
+    node2 = dll_insert(head, 30);
+    node3 = dll_insert(head, -12);
+    node4 = dll_insert(head, 0);
+    node5 = dll_insert(head, 20);
+    node6 = dll_insert(head, -189);
     retrieved = dll_search(head, -67);
 
     ck_assert_int_eq(retrieved == NULL, false);
@@ -222,25 +255,42 @@ START_TEST(test_dll_search_3)
     ck_assert_int_eq(retrieved->prev->prev->prev->prev->data.key, 20);
     ck_assert_int_eq(retrieved->prev->prev->prev->prev->prev->data.key, -189);
 
-    free(retrieved);
+    free(node6);
+    free(node5);
+    free(node4);
+    free(node3);
+    free(node2);
+    free(node1);
+    free(head);
 }
 END_TEST
 
 START_TEST(test_dll_search_4)
 {
     DoublyLinkedList* retrieved;
+    DoublyLinkedList* node1;
+    DoublyLinkedList* node2;
+    DoublyLinkedList* node3;
+    DoublyLinkedList* node4;
+    DoublyLinkedList* node5;
+    DoublyLinkedList* node6;
     DoublyLinkedList** head;
 
-    retrieved = malloc(sizeof(DoublyLinkedList*));
+    node1 = malloc(sizeof(DoublyLinkedList*));
+    node2 = malloc(sizeof(DoublyLinkedList*));
+    node3 = malloc(sizeof(DoublyLinkedList*));
+    node4 = malloc(sizeof(DoublyLinkedList*));
+    node5 = malloc(sizeof(DoublyLinkedList*));
+    node6 = malloc(sizeof(DoublyLinkedList*));
     head = malloc(sizeof(DoublyLinkedList**));
 
     *head = NULL;
-    dll_insert(head, -67);
-    dll_insert(head, 30);
-    dll_insert(head, -12);
-    dll_insert(head, 0);
-    dll_insert(head, 20);
-    dll_insert(head, -189);
+    node1 = dll_insert(head, -67);
+    node2 = dll_insert(head, 30);
+    node3 = dll_insert(head, -12);
+    node4 = dll_insert(head, 0);
+    node5 = dll_insert(head, 20);
+    node6 = dll_insert(head, -189);
     retrieved = dll_search(head, -189);
 
     ck_assert_int_eq(retrieved == NULL, false);
@@ -253,7 +303,13 @@ START_TEST(test_dll_search_4)
     ck_assert_int_eq(retrieved->next->next->next->next->data.key, 30);
     ck_assert_int_eq(retrieved->next->next->next->next->next->data.key, -67);
 
-    free(retrieved);
+    free(node6);
+    free(node5);
+    free(node4);
+    free(node3);
+    free(node2);
+    free(node1);
+    free(head);
 }
 END_TEST
 
@@ -296,7 +352,9 @@ START_TEST(test_dll_delete_1)
     ck_assert_int_eq((*head)->next == NULL, true);
     ck_assert_int_eq((*head)->prev == NULL, true);
 
+    free(node2);
     free(node1);
+    free(head);
 }
 END_TEST
 
@@ -340,6 +398,8 @@ START_TEST(test_dll_delete_2)
     ck_assert_int_eq((*head)->prev == NULL, true);
 
     free(node2);
+    free(node1);
+    free(head);
 }
 END_TEST
 
@@ -371,6 +431,7 @@ START_TEST(test_dll_delete_3)
     ck_assert_int_eq((*head) == NULL, true);
 
     free(node1);
+    free(head);
 }
 END_TEST
 
@@ -431,6 +492,11 @@ START_TEST(test_dll_delete_4)
     ck_assert_int_eq(node1->prev == NULL, false);
     ck_assert_int_eq(node1->next == NULL, true);
     ck_assert_int_eq(node1->prev->data.key, 150);
+
+    free(node3);
+    free(node2);
+    free(node1);
+    free(head);
 }
 END_TEST
 
@@ -463,6 +529,7 @@ START_TEST(test_dll_delete_5)
     ck_assert_int_eq((*head)->next->data.key, 25);
 
     free(node);
+    free(head);
 }
 END_TEST
 
@@ -490,8 +557,8 @@ START_TEST(test_dll_delete_6)
     ck_assert_int_eq((*head)->prev == NULL, true);
     ck_assert_int_eq((*head)->next == NULL, true);
 
-    free(node1);
     free(node2);
+    free(node1);
     free(head);
 }
 END_TEST
@@ -504,9 +571,7 @@ Suite *make_dll_suite(void)
     s = suite_create("DoublyLinkedList Test Suite");
 
     /* Creation test case */
-    tc_core = tcase_create("Test Cases with Setup and Teardown");
-
-    tcase_add_checked_fixture(tc_core, setup, teardown);
+    tc_core = tcase_create("Test Cases without Setup and Teardown");
 
     tcase_add_test(tc_core, test_dll_insert_1);
     tcase_add_test(tc_core, test_dll_insert_2);

--- a/tests/test_queue.c
+++ b/tests/test_queue.c
@@ -21,6 +21,7 @@ void setup(void)
 
 void teardown(void)
 {
+    free(el);
     free(q);
 }
 

--- a/tests/test_sll.c
+++ b/tests/test_sll.c
@@ -13,7 +13,6 @@ START_TEST(test_sll_insert_1)
     SinglyLinkedList* node1;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -39,8 +38,6 @@ START_TEST(test_sll_insert_2)
     SinglyLinkedList* node2;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -75,10 +72,6 @@ START_TEST(test_sll_insert_3)
     SinglyLinkedList* node4;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -124,7 +117,6 @@ START_TEST(test_sll_search_1)
     SinglyLinkedList* node1;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_search(head, 100);
@@ -146,7 +138,6 @@ START_TEST(test_sll_search_2)
     SinglyLinkedList* retrieved;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -178,8 +169,6 @@ START_TEST(test_sll_search_3)
     SinglyLinkedList* node2;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -210,8 +199,6 @@ START_TEST(test_sll_search_4)
     SinglyLinkedList* retrieved;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -252,8 +239,6 @@ START_TEST(test_sll_search_5)
     SinglyLinkedList* retrieved;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -293,8 +278,6 @@ START_TEST(test_sll_search_6)
     SinglyLinkedList* retrieved;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -333,10 +316,6 @@ START_TEST(test_sll_search_7)
     SinglyLinkedList* retrieved;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -389,10 +368,6 @@ START_TEST(test_sll_search_8)
     SinglyLinkedList* retrieved;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -450,10 +425,6 @@ START_TEST(test_sll_search_9)
     SinglyLinkedList* retrieved;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -506,7 +477,6 @@ START_TEST(test_sll_delete_1)
     SinglyLinkedList* node1;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -537,8 +507,6 @@ START_TEST(test_sll_delete_2)
     SinglyLinkedList* node2;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -579,8 +547,6 @@ START_TEST(test_sll_delete_3)
     SinglyLinkedList* node2;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -621,8 +587,6 @@ START_TEST(test_sll_delete_4)
     SinglyLinkedList* node2;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -661,8 +625,6 @@ START_TEST(test_sll_delete_5)
     SinglyLinkedList* node2;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -703,10 +665,6 @@ START_TEST(test_sll_delete_6)
     SinglyLinkedList* node4;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -778,10 +736,6 @@ START_TEST(test_sll_delete_7)
     SinglyLinkedList* node4;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -853,10 +807,6 @@ START_TEST(test_sll_delete_8)
     SinglyLinkedList* node4;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -928,10 +878,6 @@ START_TEST(test_sll_delete_9)
     SinglyLinkedList* node4;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -1003,10 +949,6 @@ START_TEST(test_sll_delete_10)
     SinglyLinkedList* node4;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -1076,10 +1018,6 @@ START_TEST(test_sll_delete_11)
     SinglyLinkedList* node4;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -1149,10 +1087,6 @@ START_TEST(test_sll_delete_12)
     SinglyLinkedList* node4;
 
     head = malloc(sizeof(SinglyLinkedList**));
-    node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
-    node3 = malloc(sizeof(SinglyLinkedList*));
-    node4 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);

--- a/tests/test_sll.c
+++ b/tests/test_sll.c
@@ -143,15 +143,14 @@ START_TEST(test_sll_search_2)
 {
     SinglyLinkedList** head;
     SinglyLinkedList* node1;
-    SinglyLinkedList* node2;
+    SinglyLinkedList* retrieved;
 
     head = malloc(sizeof(SinglyLinkedList**));
     node1 = malloc(sizeof(SinglyLinkedList*));
-    node2 = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
-    node2 = sll_search(head, 200);
+    retrieved = sll_search(head, 200);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -162,10 +161,10 @@ START_TEST(test_sll_search_2)
     ck_assert_int_eq((*head)->data.key, 200);
     ck_assert_int_eq(node1->data.key, 200);
 
-    ck_assert_int_eq((*head) == node2, true);
-    ck_assert_int_eq(node2->next == NULL, true);
-    ck_assert_int_eq(node2->data.key, 200);
-    ck_assert_int_eq(node2 == node1, true);
+    ck_assert_int_eq((*head) == retrieved, true);
+    ck_assert_int_eq(retrieved->next == NULL, true);
+    ck_assert_int_eq(retrieved->data.key, 200);
+    ck_assert_int_eq(retrieved == node1, true);
 
     free(node1);
     free(head);
@@ -198,6 +197,7 @@ START_TEST(test_sll_search_3)
     ck_assert_int_eq(node2 == NULL, true);
 
     free(node1);
+    free(node2);
     free(head);
 }
 END_TEST
@@ -212,7 +212,6 @@ START_TEST(test_sll_search_4)
     head = malloc(sizeof(SinglyLinkedList**));
     node1 = malloc(sizeof(SinglyLinkedList*));
     node2 = malloc(sizeof(SinglyLinkedList*));
-    retrieved = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -255,7 +254,6 @@ START_TEST(test_sll_search_5)
     head = malloc(sizeof(SinglyLinkedList**));
     node1 = malloc(sizeof(SinglyLinkedList*));
     node2 = malloc(sizeof(SinglyLinkedList*));
-    retrieved = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -297,7 +295,6 @@ START_TEST(test_sll_search_6)
     head = malloc(sizeof(SinglyLinkedList**));
     node1 = malloc(sizeof(SinglyLinkedList*));
     node2 = malloc(sizeof(SinglyLinkedList*));
-    retrieved = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -340,7 +337,6 @@ START_TEST(test_sll_search_7)
     node2 = malloc(sizeof(SinglyLinkedList*));
     node3 = malloc(sizeof(SinglyLinkedList*));
     node4 = malloc(sizeof(SinglyLinkedList*));
-    retrieved = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -397,7 +393,6 @@ START_TEST(test_sll_search_8)
     node2 = malloc(sizeof(SinglyLinkedList*));
     node3 = malloc(sizeof(SinglyLinkedList*));
     node4 = malloc(sizeof(SinglyLinkedList*));
-    retrieved = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -459,7 +454,6 @@ START_TEST(test_sll_search_9)
     node2 = malloc(sizeof(SinglyLinkedList*));
     node3 = malloc(sizeof(SinglyLinkedList*));
     node4 = malloc(sizeof(SinglyLinkedList*));
-    retrieved = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);


### PR DESCRIPTION
# Fix memory allocation in unit tests

## Description

Remove unnecessary memory allocations. Free memory allocated to struct pointers. Create Register/Key header. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Existing unit tests 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules