### PR TITLE
Fix ptr malloc. Replace Key for Reg in funcs

### DIFF
--- a/src/cdll.c
+++ b/src/cdll.c
@@ -10,7 +10,7 @@ void cdll_init(CircularDoublyLinkedList* nil)
 CircularDoublyLinkedList* cdll_insert(CircularDoublyLinkedList* nil, Key k)
 {
     CircularDoublyLinkedList* node;
-    node = malloc(sizeof(CircularDoublyLinkedList*));
+    node = malloc(sizeof(CircularDoublyLinkedList));
     node->data.key = k;
      
     node->next = nil->next;

--- a/src/cdll.c
+++ b/src/cdll.c
@@ -7,11 +7,11 @@ void cdll_init(CircularDoublyLinkedList* nil)
     nil->prev = nil;    
 }
 
-CircularDoublyLinkedList* cdll_insert(CircularDoublyLinkedList* nil, Key k)
+CircularDoublyLinkedList* cdll_insert(CircularDoublyLinkedList* nil, Register reg)
 {
     CircularDoublyLinkedList* node;
     node = malloc(sizeof(CircularDoublyLinkedList));
-    node->data.key = k;
+    node->data = reg;
      
     node->next = nil->next;
     nil->next->prev = node;

--- a/src/csll.c
+++ b/src/csll.c
@@ -3,12 +3,12 @@
 #include <csll.h>
 
 CircularSinglyLinkedList* csll_insert_begin(CircularSinglyLinkedList** tail,
-                                           Key k)
+                                            Register reg)
 {
     CircularSinglyLinkedList* node;
 
     node = malloc(sizeof(CircularSinglyLinkedList));
-    node->data.key = k;
+    node->data = reg;
 
     if ((*tail) == NULL)
     {
@@ -25,12 +25,12 @@ CircularSinglyLinkedList* csll_insert_begin(CircularSinglyLinkedList** tail,
 }
 
 CircularSinglyLinkedList* csll_insert_end(CircularSinglyLinkedList** tail,
-                                         Key k)
+                                          Register reg)
 {
     CircularSinglyLinkedList* node;
 
     node = malloc(sizeof(CircularSinglyLinkedList));
-    node->data.key = k;
+    node->data = reg;
 
     if ((*tail) == NULL)
     {

--- a/src/csll.c
+++ b/src/csll.c
@@ -7,7 +7,7 @@ CircularSinglyLinkedList* csll_insert_begin(CircularSinglyLinkedList** tail,
 {
     CircularSinglyLinkedList* node;
 
-    node = malloc(sizeof(CircularSinglyLinkedList*));
+    node = malloc(sizeof(CircularSinglyLinkedList));
     node->data.key = k;
 
     if ((*tail) == NULL)
@@ -29,7 +29,7 @@ CircularSinglyLinkedList* csll_insert_end(CircularSinglyLinkedList** tail,
 {
     CircularSinglyLinkedList* node;
 
-    node = malloc(sizeof(CircularSinglyLinkedList*));
+    node = malloc(sizeof(CircularSinglyLinkedList));
     node->data.key = k;
 
     if ((*tail) == NULL)

--- a/src/dll.c
+++ b/src/dll.c
@@ -4,7 +4,7 @@
 DoublyLinkedList* dll_insert(DoublyLinkedList** head, Key k)
 {
     DoublyLinkedList* node;
-    node = malloc(sizeof(DoublyLinkedList*));
+    node = malloc(sizeof(DoublyLinkedList));
     node->data.key = k;
     node->next = *head;
     node->prev = NULL;

--- a/src/dll.c
+++ b/src/dll.c
@@ -1,11 +1,11 @@
 #include <dll.h>
 #include <malloc.h>
 
-DoublyLinkedList* dll_insert(DoublyLinkedList** head, Key k)
+DoublyLinkedList* dll_insert(DoublyLinkedList** head, Register reg)
 {
     DoublyLinkedList* node;
     node = malloc(sizeof(DoublyLinkedList));
-    node->data.key = k;
+    node->data = reg;
     node->next = *head;
     node->prev = NULL;
 

--- a/src/include/cdll.h
+++ b/src/include/cdll.h
@@ -41,10 +41,10 @@ void cdll_init(CircularDoublyLinkedList* nil);
  * pointer to inserted node.
  *
  * @param nil Pointer to nil node. 
- * @param k Key for Register of inserted node.
+ * @param reg Register of inserted node.
  * @return Pointer to inserted node.
  */
-CircularDoublyLinkedList* cdll_insert(CircularDoublyLinkedList* nil, Key k);
+CircularDoublyLinkedList* cdll_insert(CircularDoublyLinkedList* nil, Register reg);
 
 /** @brief Retrieves node in Circular Doubly Linked List via key. 
  *

--- a/src/include/csll.h
+++ b/src/include/csll.h
@@ -27,10 +27,11 @@ CircularSinglyLinkedList;
  * pointer to added node.
  *
  * @param tail Double pointer to tail of Circular Singly Linked List. 
- * @param k Key for Register of inserted node.
+ * @param reg Register of inserted node.
  * @return Pointer to inserted node.
  */
-CircularSinglyLinkedList* csll_insert_begin(CircularSinglyLinkedList** tail, Key k);
+CircularSinglyLinkedList* csll_insert_begin(CircularSinglyLinkedList** tail,
+                                            Register reg);
 
 /** @brief Inserts node at end of Circular Singly Linked List.
  *  
@@ -40,10 +41,11 @@ CircularSinglyLinkedList* csll_insert_begin(CircularSinglyLinkedList** tail, Key
  * pointer with new tail of the linked list.
  *
  * @param tail Double pointer to tail of Circular Singly Linked List. 
- * @param k Key for Register of inserted node.
+ * @param reg Register of inserted node.
  * @return Pointer to inserted node.
  */
-CircularSinglyLinkedList* csll_insert_end(CircularSinglyLinkedList** tail, Key k);
+CircularSinglyLinkedList* csll_insert_end(CircularSinglyLinkedList** tail,
+                                          Register reg);
 
 /** @brief Retrieves node from Circular Singly Linked List via key. 
  *

--- a/src/include/dll.h
+++ b/src/include/dll.h
@@ -30,10 +30,10 @@ DoublyLinkedList;
  * the linked list.
  *
  * @param head Double pointer to head of Doubly Linked List. 
- * @param k Key for Register of inserted node.
+ * @param reg Register of inserted node.
  * @return Pointer to inserted node.
  */
-DoublyLinkedList* dll_insert(DoublyLinkedList** head, Key k);
+DoublyLinkedList* dll_insert(DoublyLinkedList** head, Register reg);
 
 /** @brief Retrieves node from Doubly Linked List via key. 
  *

--- a/src/include/seq_list.h
+++ b/src/include/seq_list.h
@@ -126,7 +126,7 @@ int sentinel_search(SeqList* sl, Key k);
  * @param sl Sequential List as pointer
  * @return Wheter element could be removed
  */
-bool remove_elem(Key key, SeqList* sl);
+bool remove_elem(SeqList* sl, Key key);
 
 /** @brief Prints elements in Sequential List
  *

--- a/src/include/sll.h
+++ b/src/include/sll.h
@@ -28,10 +28,10 @@ SinglyLinkedList;
  * the Singly Linked List.
  *
  * @param head Double pointer to head of Singly Linked List. 
- * @param k Key for Register of inserted node.
+ * @param reg Register of inserted node.
  * @return Pointer to inserted node.
  */
-SinglyLinkedList* sll_insert(SinglyLinkedList** head, Key k);
+SinglyLinkedList* sll_insert(SinglyLinkedList** head, Register reg);
 
 /** @brief Retrieves node from Singly Linked List via key. 
  *

--- a/src/seq_list.c
+++ b/src/seq_list.c
@@ -123,7 +123,7 @@ bool insert_elem(SeqList* sl, Register reg, int i)
     }
 }
 
-bool remove_elem(Key key, SeqList* sl)
+bool remove_elem(SeqList* sl, Key key)
 {
     int pos, j;
     pos = seq_search(sl, key);

--- a/src/sll.c
+++ b/src/sll.c
@@ -1,11 +1,11 @@
 #include <malloc.h>
 #include <sll.h>
 
-SinglyLinkedList* sll_insert(SinglyLinkedList** head, Key k)
+SinglyLinkedList* sll_insert(SinglyLinkedList** head, Register reg)
 {
     SinglyLinkedList* node;
     node = malloc(sizeof(SinglyLinkedList));
-    node->data.key = k;
+    node->data = reg;
     node->next = (*head);
 
     (*head) = node;

--- a/tests/test_cdll.c
+++ b/tests/test_cdll.c
@@ -12,7 +12,7 @@ Suite *make_cdll_suite(void);
 START_TEST(test_cdll_init_1)
 {
     CircularDoublyLinkedList* nil;
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
     
     cdll_init(nil);
     ck_assert_int_eq(nil->next == nil, true);
@@ -27,7 +27,7 @@ START_TEST(test_cdll_insert_1)
     CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -52,7 +52,7 @@ START_TEST(test_cdll_insert_2)
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -90,7 +90,7 @@ START_TEST(test_cdll_insert_3)
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* node3;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -136,7 +136,7 @@ START_TEST(test_cdll_search_1)
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* retrieved;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -168,7 +168,7 @@ START_TEST(test_cdll_search_2)
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* retrieved;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -199,7 +199,7 @@ START_TEST(test_cdll_search_3)
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* retrieved;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -245,7 +245,7 @@ START_TEST(test_cdll_search_4)
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* retrieved;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -292,7 +292,7 @@ START_TEST(test_cdll_search_5)
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* retrieved;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -343,7 +343,7 @@ START_TEST(test_cdll_search_6)
     CircularDoublyLinkedList* node3;
     CircularDoublyLinkedList* retrieved;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -399,7 +399,7 @@ START_TEST(test_cdll_search_7)
     CircularDoublyLinkedList* node3;
     CircularDoublyLinkedList* retrieved;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -461,7 +461,7 @@ START_TEST(test_cdll_search_8)
     CircularDoublyLinkedList* node3;
     CircularDoublyLinkedList* retrieved;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -515,7 +515,7 @@ START_TEST(test_cdll_delete_1)
     CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -546,7 +546,7 @@ START_TEST(test_cdll_delete_2)
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -598,7 +598,7 @@ START_TEST(test_cdll_delete_3)
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -651,7 +651,7 @@ START_TEST(test_cdll_delete_4)
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* node3;
 
-    nil = malloc(sizeof(CircularDoublyLinkedList*));
+    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);

--- a/tests/test_cdll.c
+++ b/tests/test_cdll.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <cdll.h>
 
+Register* reg;
 CircularDoublyLinkedList* nil;
 
 void setup(void);
@@ -14,10 +15,12 @@ Suite *make_cdll_suite(void);
 void setup(void)
 {
     nil = malloc(sizeof(CircularDoublyLinkedList));
+    reg = malloc(sizeof(Register));
 }
 
 void teardown(void)
 {
+    free(reg);
     free(nil);
 }
 
@@ -34,7 +37,8 @@ START_TEST(test_cdll_insert_1)
     CircularDoublyLinkedList* node1;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
 
     ck_assert_int_eq(nil->prev == node1, true);
     ck_assert_int_eq(nil->next == node1, true);    
@@ -55,8 +59,10 @@ START_TEST(test_cdll_insert_2)
     CircularDoublyLinkedList* node2;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
-    node2 = cdll_insert(nil, -9);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = -9;
+    node2 = cdll_insert(nil, *reg);
 
     ck_assert_int_eq(nil->next == node2, true);
     ck_assert_int_eq(nil->prev == node1, true);
@@ -89,9 +95,12 @@ START_TEST(test_cdll_insert_3)
     CircularDoublyLinkedList* node3;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, -2);
-    node2 = cdll_insert(nil, 5);
-    node3 = cdll_insert(nil, 0);
+    reg->key = -2;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = 5;
+    node2 = cdll_insert(nil, *reg);
+    reg->key = 0;
+    node3 = cdll_insert(nil, *reg);
 
     ck_assert_int_eq(nil->next == node3, true);
     ck_assert_int_eq(nil->prev == node1, true);
@@ -131,7 +140,8 @@ START_TEST(test_cdll_search_1)
     CircularDoublyLinkedList* retrieved;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
     retrieved = cdll_search(nil, 17);
 
     ck_assert_int_eq(nil->prev == node1, true);
@@ -159,7 +169,8 @@ START_TEST(test_cdll_search_2)
     CircularDoublyLinkedList* retrieved;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
     retrieved = cdll_search(nil, 25);
 
     ck_assert_int_eq(nil->prev == node1, true);
@@ -186,8 +197,10 @@ START_TEST(test_cdll_search_3)
     CircularDoublyLinkedList* retrieved;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
-    node2 = cdll_insert(nil, -9);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = -9;
+    node2 = cdll_insert(nil, *reg);
     retrieved = cdll_search(nil, -9);
 
     ck_assert_int_eq(nil->next == node2, true);
@@ -228,8 +241,10 @@ START_TEST(test_cdll_search_4)
     CircularDoublyLinkedList* retrieved;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
-    node2 = cdll_insert(nil, -9);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = -9;
+    node2 = cdll_insert(nil, *reg);
     retrieved = cdll_search(nil, 17);
 
     ck_assert_int_eq(nil->next == node2, true);
@@ -271,8 +286,10 @@ START_TEST(test_cdll_search_5)
     CircularDoublyLinkedList* retrieved;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
-    node2 = cdll_insert(nil, -9);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = -9;
+    node2 = cdll_insert(nil, *reg);
     retrieved = cdll_search(nil, -22);
 
     ck_assert_int_eq(nil->next == node2, true);
@@ -317,9 +334,12 @@ START_TEST(test_cdll_search_6)
     CircularDoublyLinkedList* retrieved;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, -2);
-    node2 = cdll_insert(nil, 5);
-    node3 = cdll_insert(nil, 0);
+    reg->key = -2;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = 5;
+    node2 = cdll_insert(nil, *reg);
+    reg->key = 0;
+    node3 = cdll_insert(nil, *reg);
     retrieved = cdll_search(nil, 0);
 
     ck_assert_int_eq(nil->next == node3, true);
@@ -369,9 +389,12 @@ START_TEST(test_cdll_search_7)
     CircularDoublyLinkedList* retrieved;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, -2);
-    node2 = cdll_insert(nil, 5);
-    node3 = cdll_insert(nil, 0);
+    reg->key = -2;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = 5;
+    node2 = cdll_insert(nil, *reg);
+    reg->key = 0;
+    node3 = cdll_insert(nil, *reg);
     retrieved = cdll_search(nil, 214350);
 
     ck_assert_int_eq(nil->next == node3, true);
@@ -427,9 +450,12 @@ START_TEST(test_cdll_search_8)
     CircularDoublyLinkedList* retrieved;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, -2);
-    node2 = cdll_insert(nil, 5);
-    node3 = cdll_insert(nil, 0);
+    reg->key = -2;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = 5;
+    node2 = cdll_insert(nil, *reg);
+    reg->key = 0;
+    node3 = cdll_insert(nil, *reg);
     retrieved = cdll_search(nil, 5);
 
     ck_assert_int_eq(nil->next == node3, true);
@@ -477,7 +503,8 @@ START_TEST(test_cdll_delete_1)
     CircularDoublyLinkedList* node1;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
 
     ck_assert_int_eq(nil->prev == node1, true);
     ck_assert_int_eq(nil->next == node1, true);    
@@ -504,8 +531,10 @@ START_TEST(test_cdll_delete_2)
     CircularDoublyLinkedList* node2;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
-    node2 = cdll_insert(nil, -9);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = -9;
+    node2 = cdll_insert(nil, *reg);
 
     ck_assert_int_eq(nil->next == node2, true);
     ck_assert_int_eq(nil->prev == node1, true);
@@ -552,8 +581,10 @@ START_TEST(test_cdll_delete_3)
     CircularDoublyLinkedList* node2;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, 17);
-    node2 = cdll_insert(nil, -9);
+    reg->key = 17;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = -9;
+    node2 = cdll_insert(nil, *reg);
 
     ck_assert_int_eq(nil->next == node2, true);
     ck_assert_int_eq(nil->prev == node1, true);
@@ -601,9 +632,12 @@ START_TEST(test_cdll_delete_4)
     CircularDoublyLinkedList* node3;
 
     cdll_init(nil);
-    node1 = cdll_insert(nil, -2);
-    node2 = cdll_insert(nil, 5);
-    node3 = cdll_insert(nil, 0);
+    reg->key = -2;
+    node1 = cdll_insert(nil, *reg);
+    reg->key = 5;
+    node2 = cdll_insert(nil, *reg);
+    reg->key = 0;
+    node3 = cdll_insert(nil, *reg);
 
     ck_assert_int_eq(nil->next == node3, true);
     ck_assert_int_eq(nil->prev == node1, true);

--- a/tests/test_cdll.c
+++ b/tests/test_cdll.c
@@ -5,29 +5,33 @@
 #include <stdbool.h>
 #include <cdll.h>
 
-CircularDoublyLinkedList* node;
+CircularDoublyLinkedList* nil;
 
+void setup(void);
+void teardown(void);
 Suite *make_cdll_suite(void);
+
+void setup(void)
+{
+    nil = malloc(sizeof(CircularDoublyLinkedList));
+}
+
+void teardown(void)
+{
+    free(nil);
+}
 
 START_TEST(test_cdll_init_1)
 {
-    CircularDoublyLinkedList* nil;
-    nil = malloc(sizeof(CircularDoublyLinkedList));
-    
     cdll_init(nil);
     ck_assert_int_eq(nil->next == nil, true);
     ck_assert_int_eq(nil->prev == nil, true);
-
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_insert_1)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -42,17 +46,13 @@ START_TEST(test_cdll_insert_1)
     ck_assert_int_eq(node1->data.key, 17);
 
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_insert_2)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -79,18 +79,14 @@ START_TEST(test_cdll_insert_2)
 
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_insert_3)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* node3;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -126,17 +122,13 @@ START_TEST(test_cdll_insert_3)
     free(node3);
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_search_1)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* retrieved;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -158,17 +150,13 @@ START_TEST(test_cdll_search_1)
     ck_assert_int_eq(retrieved == node1, true);
 
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_search_2)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* retrieved;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -188,18 +176,14 @@ START_TEST(test_cdll_search_2)
     ck_assert_int_eq(retrieved == nil, true);
 
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_search_3)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* retrieved;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -234,18 +218,14 @@ START_TEST(test_cdll_search_3)
 
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_search_4)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* retrieved;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -281,18 +261,14 @@ START_TEST(test_cdll_search_4)
 
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_search_5)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* retrieved;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -328,22 +304,17 @@ START_TEST(test_cdll_search_5)
     ck_assert_int_eq(retrieved->prev->prev->prev == retrieved, true);
     ck_assert_int_eq(retrieved == nil, true);
 
-
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_search_6)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* node3;
     CircularDoublyLinkedList* retrieved;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -387,19 +358,15 @@ START_TEST(test_cdll_search_6)
     free(node3);
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_search_7)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* node3;
     CircularDoublyLinkedList* retrieved;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -449,19 +416,15 @@ START_TEST(test_cdll_search_7)
     free(node3);
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_search_8)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* node3;
     CircularDoublyLinkedList* retrieved;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -506,16 +469,12 @@ START_TEST(test_cdll_search_8)
     free(node3);
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_delete_1)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -536,17 +495,13 @@ START_TEST(test_cdll_delete_1)
     ck_assert_int_eq(node1->data.key, 17);
 
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_delete_2)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -588,17 +543,13 @@ START_TEST(test_cdll_delete_2)
 
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_delete_3)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, 17);
@@ -640,18 +591,14 @@ START_TEST(test_cdll_delete_3)
 
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
 START_TEST(test_cdll_delete_4)
 {
-    CircularDoublyLinkedList* nil;
     CircularDoublyLinkedList* node1;
     CircularDoublyLinkedList* node2;
     CircularDoublyLinkedList* node3;
-
-    nil = malloc(sizeof(CircularDoublyLinkedList));
 
     cdll_init(nil);
     node1 = cdll_insert(nil, -2);
@@ -709,7 +656,6 @@ START_TEST(test_cdll_delete_4)
     free(node3);
     free(node2);
     free(node1);
-    free(nil);
 }
 END_TEST
 
@@ -721,7 +667,9 @@ Suite *make_cdll_suite(void)
     s = suite_create("DoublyLinkedList Test Suite");
 
     /* Creation test case */
-    tc_core = tcase_create("Test Cases with no Setup/Teardown");
+    tc_core = tcase_create("Test Cases with Setup/Teardown");
+
+    tcase_add_checked_fixture(tc_core, setup, teardown);
 
     tcase_add_test(tc_core, test_cdll_init_1);
 

--- a/tests/test_csll.c
+++ b/tests/test_csll.c
@@ -12,7 +12,7 @@ START_TEST(test_csll_insert_begin_1)
     CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -39,7 +39,7 @@ START_TEST(test_csll_insert_begin_2)
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -83,7 +83,7 @@ START_TEST(test_csll_insert_begin_3)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -141,7 +141,7 @@ START_TEST(test_csll_insert_end_1)
     CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -168,7 +168,7 @@ START_TEST(test_csll_insert_end_2)
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -213,7 +213,7 @@ START_TEST(test_csll_insert_end_3)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -273,7 +273,7 @@ START_TEST(test_csll_search_1)
     CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* retrieved;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     retrieved = csll_search(tail, 10);
@@ -294,7 +294,7 @@ START_TEST(test_csll_search_2)
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -365,7 +365,7 @@ START_TEST(test_csll_search_3)
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -436,7 +436,7 @@ START_TEST(test_csll_search_4)
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -501,7 +501,7 @@ START_TEST(test_csll_search_5)
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -572,7 +572,7 @@ START_TEST(test_csll_search_6)
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -647,7 +647,7 @@ START_TEST(test_csll_search_7)
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -721,7 +721,7 @@ START_TEST(test_csll_search_8)
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -795,7 +795,7 @@ START_TEST(test_csll_search_9)
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -859,7 +859,7 @@ START_TEST(test_csll_delete_1)
     CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -890,7 +890,7 @@ START_TEST(test_csll_delete_2)
     CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -923,7 +923,7 @@ START_TEST(test_csll_delete_3)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1010,7 +1010,7 @@ START_TEST(test_csll_delete_4)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1099,7 +1099,7 @@ START_TEST(test_csll_delete_5)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1177,7 +1177,7 @@ START_TEST(test_csll_delete_6)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1255,7 +1255,7 @@ START_TEST(test_csll_delete_7)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1333,7 +1333,7 @@ START_TEST(test_csll_delete_8)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1411,7 +1411,7 @@ START_TEST(test_csll_delete_9)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1478,7 +1478,7 @@ START_TEST(test_csll_delete_10)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1545,7 +1545,7 @@ START_TEST(test_csll_delete_11)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1612,7 +1612,7 @@ START_TEST(test_csll_delete_12)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1679,7 +1679,7 @@ START_TEST(test_csll_delete_13)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1746,7 +1746,7 @@ START_TEST(test_csll_insert_begin_end_1)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1806,7 +1806,7 @@ START_TEST(test_csll_insert_begin_end_2)
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
 
-    tail = malloc(sizeof(CircularSinglyLinkedList**));
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);

--- a/tests/test_csll.c
+++ b/tests/test_csll.c
@@ -5,14 +5,25 @@
 #include <stdbool.h>
 #include <csll.h>
 
+CircularSinglyLinkedList** tail;
+
+void setup(void);
+void teardown(void);
 Suite *make_dll_suite(void);
+
+void setup(void)
+{
+    tail = malloc(sizeof(CircularSinglyLinkedList*));
+}
+
+void teardown(void)
+{
+    free(tail);
+}
 
 START_TEST(test_csll_insert_begin_1)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -29,17 +40,13 @@ START_TEST(test_csll_insert_begin_1)
     ck_assert_int_eq(node1 == (*tail), true);
 
     free(node1);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_insert_begin_2)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -72,18 +79,14 @@ START_TEST(test_csll_insert_begin_2)
 
     free(node1);
     free(node2);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_insert_begin_3)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -132,16 +135,12 @@ START_TEST(test_csll_insert_begin_3)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_insert_end_1)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -158,17 +157,13 @@ START_TEST(test_csll_insert_end_1)
     ck_assert_int_eq(node1 == (*tail), true);
 
     free(node1);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_insert_end_2)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -202,18 +197,14 @@ START_TEST(test_csll_insert_end_2)
 
     free(node1);
     free(node2);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_insert_end_3)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -264,16 +255,12 @@ START_TEST(test_csll_insert_end_3)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_search_1)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* retrieved;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     retrieved = csll_search(tail, 10);
@@ -281,20 +268,15 @@ START_TEST(test_csll_search_1)
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, true);
     ck_assert_int_eq(retrieved == NULL, true);
-
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_search_2)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -353,19 +335,15 @@ START_TEST(test_csll_search_2)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_search_3)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -424,19 +402,15 @@ START_TEST(test_csll_search_3)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_search_4)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -489,19 +463,15 @@ START_TEST(test_csll_search_4)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_search_5)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -560,19 +530,15 @@ START_TEST(test_csll_search_5)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_search_6)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -635,19 +601,15 @@ START_TEST(test_csll_search_6)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_search_7)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -709,19 +671,15 @@ START_TEST(test_csll_search_7)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_search_8)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -783,19 +741,15 @@ START_TEST(test_csll_search_8)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_search_9)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
     CircularSinglyLinkedList* retrieved;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -850,16 +804,12 @@ START_TEST(test_csll_search_9)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_1)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -881,16 +831,12 @@ START_TEST(test_csll_delete_1)
     ck_assert_int_eq((*tail) == NULL, true);
 
     free(node1);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_2)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -912,18 +858,14 @@ START_TEST(test_csll_delete_2)
     ck_assert_int_eq((*tail) == NULL, true);
 
     free(node1);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_3)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -999,18 +941,14 @@ START_TEST(test_csll_delete_3)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_4)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1088,18 +1026,14 @@ START_TEST(test_csll_delete_4)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_5)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1166,18 +1100,14 @@ START_TEST(test_csll_delete_5)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_6)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1244,18 +1174,14 @@ START_TEST(test_csll_delete_6)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_7)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1322,18 +1248,14 @@ START_TEST(test_csll_delete_7)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_8)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1400,18 +1322,14 @@ START_TEST(test_csll_delete_8)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_9)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1467,18 +1385,14 @@ START_TEST(test_csll_delete_9)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_10)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1534,18 +1448,14 @@ START_TEST(test_csll_delete_10)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_11)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1601,18 +1511,14 @@ START_TEST(test_csll_delete_11)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_12)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1668,18 +1574,14 @@ START_TEST(test_csll_delete_12)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_delete_13)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1735,18 +1637,14 @@ START_TEST(test_csll_delete_13)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_insert_begin_end_1)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_begin(tail, 15);
@@ -1795,18 +1693,14 @@ START_TEST(test_csll_insert_begin_end_1)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
 START_TEST(test_csll_insert_begin_end_2)
 {
-    CircularSinglyLinkedList** tail;
     CircularSinglyLinkedList* node1;
     CircularSinglyLinkedList* node2;
     CircularSinglyLinkedList* node3;
-
-    tail = malloc(sizeof(CircularSinglyLinkedList*));
 
     *tail = NULL;
     node1 = csll_insert_end(tail, 15);
@@ -1857,7 +1751,6 @@ START_TEST(test_csll_insert_begin_end_2)
     free(node1);
     free(node2);
     free(node3);
-    free(tail);
 }
 END_TEST
 
@@ -1871,6 +1764,8 @@ Suite *make_dll_suite(void)
 
     /* Creation test case */
     tc_core = tcase_create("Test Cases with Setup and Teardown");
+
+    tcase_add_checked_fixture(tc_core, setup, teardown);
 
     tcase_add_test(tc_core, test_csll_insert_begin_1);
     tcase_add_test(tc_core, test_csll_insert_begin_2);

--- a/tests/test_csll.c
+++ b/tests/test_csll.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <csll.h>
 
+Register* reg;
 CircularSinglyLinkedList** tail;
 
 void setup(void);
@@ -13,11 +14,13 @@ Suite *make_dll_suite(void);
 
 void setup(void)
 {
+    reg = malloc(sizeof(Register));
     tail = malloc(sizeof(CircularSinglyLinkedList*));
 }
 
 void teardown(void)
 {
+    free(reg);
     free(tail);
 }
 
@@ -26,7 +29,8 @@ START_TEST(test_csll_insert_begin_1)
     CircularSinglyLinkedList* node1;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -49,8 +53,10 @@ START_TEST(test_csll_insert_begin_2)
     CircularSinglyLinkedList* node2;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -89,9 +95,12 @@ START_TEST(test_csll_insert_begin_3)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -143,7 +152,8 @@ START_TEST(test_csll_insert_end_1)
     CircularSinglyLinkedList* node1;
 
     *tail = NULL;
-    node1 = csll_insert_end(tail, 15);
+    reg->key = 15;
+    node1 = csll_insert_end(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -166,8 +176,10 @@ START_TEST(test_csll_insert_end_2)
     CircularSinglyLinkedList* node2;
 
     *tail = NULL;
-    node1 = csll_insert_end(tail, 15);
-    node2 = csll_insert_end(tail, -25);
+    reg->key = 15;
+    node1 = csll_insert_end(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_end(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -207,9 +219,12 @@ START_TEST(test_csll_insert_end_3)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_end(tail, 15);
-    node2 = csll_insert_end(tail, -25);
-    node3 = csll_insert_end(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_end(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_end(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_end(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -279,9 +294,12 @@ START_TEST(test_csll_search_2)
     CircularSinglyLinkedList* retrieved;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -346,9 +364,12 @@ START_TEST(test_csll_search_3)
     CircularSinglyLinkedList* retrieved;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -413,9 +434,12 @@ START_TEST(test_csll_search_4)
     CircularSinglyLinkedList* retrieved;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -474,9 +498,12 @@ START_TEST(test_csll_search_5)
     CircularSinglyLinkedList* retrieved;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -541,9 +568,12 @@ START_TEST(test_csll_search_6)
     CircularSinglyLinkedList* retrieved;
 
     *tail = NULL;
-    node1 = csll_insert_end(tail, 15);
-    node2 = csll_insert_end(tail, -25);
-    node3 = csll_insert_end(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_end(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_end(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_end(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -612,9 +642,12 @@ START_TEST(test_csll_search_7)
     CircularSinglyLinkedList* retrieved;
 
     *tail = NULL;
-    node1 = csll_insert_end(tail, 15);
-    node2 = csll_insert_end(tail, -25);
-    node3 = csll_insert_end(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_end(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_end(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_end(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -682,9 +715,12 @@ START_TEST(test_csll_search_8)
     CircularSinglyLinkedList* retrieved;
 
     *tail = NULL;
-    node1 = csll_insert_end(tail, 15);
-    node2 = csll_insert_end(tail, -25);
-    node3 = csll_insert_end(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_end(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_end(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_end(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -752,9 +788,12 @@ START_TEST(test_csll_search_9)
     CircularSinglyLinkedList* retrieved;
 
     *tail = NULL;
-    node1 = csll_insert_end(tail, 15);
-    node2 = csll_insert_end(tail, -25);
-    node3 = csll_insert_end(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_end(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_end(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_end(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -812,7 +851,8 @@ START_TEST(test_csll_delete_1)
     CircularSinglyLinkedList* node1;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -839,7 +879,8 @@ START_TEST(test_csll_delete_2)
     CircularSinglyLinkedList* node1;
 
     *tail = NULL;
-    node1 = csll_insert_end(tail, 15);
+    reg->key = 15;
+    node1 = csll_insert_end(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -868,9 +909,12 @@ START_TEST(test_csll_delete_3)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -951,9 +995,12 @@ START_TEST(test_csll_delete_4)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1036,9 +1083,12 @@ START_TEST(test_csll_delete_5)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1110,9 +1160,12 @@ START_TEST(test_csll_delete_6)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1184,9 +1237,12 @@ START_TEST(test_csll_delete_7)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1258,9 +1314,12 @@ START_TEST(test_csll_delete_8)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1332,9 +1391,12 @@ START_TEST(test_csll_delete_9)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1395,9 +1457,12 @@ START_TEST(test_csll_delete_10)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1458,9 +1523,12 @@ START_TEST(test_csll_delete_11)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1521,9 +1589,12 @@ START_TEST(test_csll_delete_12)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1584,9 +1655,12 @@ START_TEST(test_csll_delete_13)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1647,9 +1721,12 @@ START_TEST(test_csll_insert_begin_end_1)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_begin(tail, 15);
-    node2 = csll_insert_end(tail, -25);
-    node3 = csll_insert_begin(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_begin(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_end(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_begin(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);
@@ -1703,9 +1780,12 @@ START_TEST(test_csll_insert_begin_end_2)
     CircularSinglyLinkedList* node3;
 
     *tail = NULL;
-    node1 = csll_insert_end(tail, 15);
-    node2 = csll_insert_begin(tail, -25);
-    node3 = csll_insert_end(tail, 0);
+    reg->key = 15;
+    node1 = csll_insert_end(tail, *reg);
+    reg->key = -25;
+    node2 = csll_insert_begin(tail, *reg);
+    reg->key = 0;
+    node3 = csll_insert_end(tail, *reg);
 
     ck_assert_int_eq(tail == NULL, false);
     ck_assert_int_eq((*tail) == NULL, false);

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -5,16 +5,25 @@
 #include <stdbool.h>
 #include <dll.h>
 
-Register reg;
+DoublyLinkedList** head;
 
+void setup(void);
+void teardown(void);
 Suite *make_dll_suite(void);
+
+void setup(void)
+{
+    head = malloc(sizeof(DoublyLinkedList*));
+}
+
+void teardown(void)
+{
+    free(head);
+}
 
 START_TEST(test_dll_insert_1)
 {
     DoublyLinkedList* node1;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -150);
@@ -30,7 +39,6 @@ START_TEST(test_dll_insert_1)
     ck_assert_int_eq((*head)->next == NULL, true);
 
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -38,9 +46,6 @@ START_TEST(test_dll_insert_2)
 {
     DoublyLinkedList* node1;
     DoublyLinkedList* node2;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, 10);
@@ -71,7 +76,6 @@ START_TEST(test_dll_insert_2)
 
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -81,9 +85,6 @@ START_TEST(test_dll_insert_3)
     DoublyLinkedList* node2;
     DoublyLinkedList* node3;
     DoublyLinkedList* node4;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -136,7 +137,6 @@ START_TEST(test_dll_insert_3)
     free(node3);
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -147,9 +147,6 @@ START_TEST(test_dll_search_1)
     DoublyLinkedList* node2;
     DoublyLinkedList* node3;
     DoublyLinkedList* node4;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -170,7 +167,6 @@ START_TEST(test_dll_search_1)
     free(node3);
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -181,9 +177,6 @@ START_TEST(test_dll_search_2)
     DoublyLinkedList* node2;
     DoublyLinkedList* node3;
     DoublyLinkedList* node4;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, 23);
@@ -198,7 +191,6 @@ START_TEST(test_dll_search_2)
     free(node3);
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -211,9 +203,6 @@ START_TEST(test_dll_search_3)
     DoublyLinkedList* node4;
     DoublyLinkedList* node5;
     DoublyLinkedList* node6;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -240,7 +229,6 @@ START_TEST(test_dll_search_3)
     free(node3);
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -253,9 +241,6 @@ START_TEST(test_dll_search_4)
     DoublyLinkedList* node4;
     DoublyLinkedList* node5;
     DoublyLinkedList* node6;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -282,7 +267,6 @@ START_TEST(test_dll_search_4)
     free(node3);
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -290,9 +274,6 @@ START_TEST(test_dll_delete_1)
 {
     DoublyLinkedList* node1;
     DoublyLinkedList* node2;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -325,7 +306,6 @@ START_TEST(test_dll_delete_1)
 
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -333,9 +313,6 @@ START_TEST(test_dll_delete_2)
 {
     DoublyLinkedList* node1;
     DoublyLinkedList* node2;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -368,16 +345,12 @@ START_TEST(test_dll_delete_2)
 
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_dll_delete_3)
 {
     DoublyLinkedList* node1;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -399,7 +372,6 @@ START_TEST(test_dll_delete_3)
     ck_assert_int_eq((*head) == NULL, true);
 
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -408,9 +380,6 @@ START_TEST(test_dll_delete_4)
     DoublyLinkedList* node1;
     DoublyLinkedList* node2;
     DoublyLinkedList* node3;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, 25);
@@ -461,16 +430,12 @@ START_TEST(test_dll_delete_4)
     free(node3);
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_dll_delete_5)
 {
     DoublyLinkedList* node;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     dll_insert(head, 25);
@@ -493,7 +458,6 @@ START_TEST(test_dll_delete_5)
     ck_assert_int_eq((*head)->next->data.key, 25);
 
     free(node);
-    free(head);
 }
 END_TEST
 
@@ -501,9 +465,6 @@ START_TEST(test_dll_delete_6)
 {
     DoublyLinkedList* node1;
     DoublyLinkedList* node2;
-    DoublyLinkedList** head;
-
-    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     dll_insert(head, 25);
@@ -521,7 +482,6 @@ START_TEST(test_dll_delete_6)
 
     free(node2);
     free(node1);
-    free(head);
 }
 END_TEST
 
@@ -533,7 +493,9 @@ Suite *make_dll_suite(void)
     s = suite_create("DoublyLinkedList Test Suite");
 
     /* Creation test case */
-    tc_core = tcase_create("Test Cases without Setup and Teardown");
+    tc_core = tcase_create("Test Cases with Setup and Teardown");
+
+    tcase_add_checked_fixture(tc_core, setup, teardown);
 
     tcase_add_test(tc_core, test_dll_insert_1);
     tcase_add_test(tc_core, test_dll_insert_2);

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <dll.h>
 
+Register* reg;
 DoublyLinkedList** head;
 
 void setup(void);
@@ -13,11 +14,13 @@ Suite *make_dll_suite(void);
 
 void setup(void)
 {
+    reg = malloc(sizeof(Register));
     head = malloc(sizeof(DoublyLinkedList*));
 }
 
 void teardown(void)
 {
+    free(reg);
     free(head);
 }
 
@@ -26,7 +29,8 @@ START_TEST(test_dll_insert_1)
     DoublyLinkedList* node1;
 
     *head = NULL;
-    node1 = dll_insert(head, -150);
+    reg->key = -150;
+    node1 = dll_insert(head, *reg);
 
     ck_assert_int_eq(node1->data.key, -150);
     ck_assert_int_eq(node1 == NULL, false);
@@ -48,8 +52,10 @@ START_TEST(test_dll_insert_2)
     DoublyLinkedList* node2;
 
     *head = NULL;
-    node1 = dll_insert(head, 10);
-    node2 = dll_insert(head, 30);
+    reg->key = 10;
+    node1 = dll_insert(head, *reg);
+    reg->key = 30;
+    node2 = dll_insert(head, *reg);
 
     /* Test collateral effect */
     ck_assert_int_eq((*head)->data.key, 30);
@@ -87,10 +93,14 @@ START_TEST(test_dll_insert_3)
     DoublyLinkedList* node4;
 
     *head = NULL;
-    node1 = dll_insert(head, -67);
-    node2 = dll_insert(head, 30);
-    node3 = dll_insert(head, -12);
-    node4 = dll_insert(head, 0);
+    reg->key = -67;
+    node1 = dll_insert(head, *reg);
+    reg->key = 30;
+    node2 = dll_insert(head, *reg);
+    reg->key = -12;
+    node3 = dll_insert(head, *reg);
+    reg->key = 0;
+    node4 = dll_insert(head, *reg);
 
     /* Test collateral effect */
     ck_assert_int_eq((*head)->data.key, 0);
@@ -149,10 +159,14 @@ START_TEST(test_dll_search_1)
     DoublyLinkedList* node4;
 
     *head = NULL;
-    node1 = dll_insert(head, -67);
-    node2 = dll_insert(head, 30);
-    node3 = dll_insert(head, -12);
-    node4 = dll_insert(head, 0);
+    reg->key = -67;
+    node1 = dll_insert(head, *reg);
+    reg->key = 30;
+    node2 = dll_insert(head, *reg);
+    reg->key = -12;
+    node3 = dll_insert(head, *reg);
+    reg->key = 0;
+    node4 = dll_insert(head, *reg);
     retrieved = dll_search(head, 30);
 
     ck_assert_int_eq(retrieved == NULL, false);
@@ -179,10 +193,14 @@ START_TEST(test_dll_search_2)
     DoublyLinkedList* node4;
 
     *head = NULL;
-    node1 = dll_insert(head, 23);
-    node2 = dll_insert(head, 5);
-    node3 = dll_insert(head, -17);
-    node4 = dll_insert(head, -10);
+    reg->key = 23;
+    node1 = dll_insert(head, *reg);
+    reg->key = 5;
+    node2 = dll_insert(head, *reg);
+    reg->key = -17;
+    node3 = dll_insert(head, *reg);
+    reg->key = -10;
+    node4 = dll_insert(head, *reg);
     retrieved = dll_search(head, 25);
 
     ck_assert_int_eq(retrieved == NULL, true);
@@ -205,12 +223,18 @@ START_TEST(test_dll_search_3)
     DoublyLinkedList* node6;
 
     *head = NULL;
-    node1 = dll_insert(head, -67);
-    node2 = dll_insert(head, 30);
-    node3 = dll_insert(head, -12);
-    node4 = dll_insert(head, 0);
-    node5 = dll_insert(head, 20);
-    node6 = dll_insert(head, -189);
+    reg->key = -67;
+    node1 = dll_insert(head, *reg);
+    reg->key = 30;
+    node2 = dll_insert(head, *reg);
+    reg->key = -12;
+    node3 = dll_insert(head, *reg);
+    reg->key = 0;
+    node4 = dll_insert(head, *reg);
+    reg->key = 20;
+    node5 = dll_insert(head, *reg);
+    reg->key = -189;
+    node6 = dll_insert(head, *reg);
     retrieved = dll_search(head, -67);
 
     ck_assert_int_eq(retrieved == NULL, false);
@@ -243,12 +267,18 @@ START_TEST(test_dll_search_4)
     DoublyLinkedList* node6;
 
     *head = NULL;
-    node1 = dll_insert(head, -67);
-    node2 = dll_insert(head, 30);
-    node3 = dll_insert(head, -12);
-    node4 = dll_insert(head, 0);
-    node5 = dll_insert(head, 20);
-    node6 = dll_insert(head, -189);
+    reg->key = -67;
+    node1 = dll_insert(head, *reg);
+    reg->key = 30;
+    node2 = dll_insert(head, *reg);
+    reg->key = -12;
+    node3 = dll_insert(head, *reg);
+    reg->key = 0;
+    node4 = dll_insert(head, *reg);
+    reg->key = 20;
+    node5 = dll_insert(head, *reg);
+    reg->key = -189;
+    node6 = dll_insert(head, *reg);
     retrieved = dll_search(head, -189);
 
     ck_assert_int_eq(retrieved == NULL, false);
@@ -276,8 +306,10 @@ START_TEST(test_dll_delete_1)
     DoublyLinkedList* node2;
 
     *head = NULL;
-    node1 = dll_insert(head, -67);
-    node2 = dll_insert(head, 30);
+    reg->key = -67;
+    node1 = dll_insert(head, *reg);
+    reg->key = 30;
+    node2 = dll_insert(head, *reg);
 
     ck_assert_int_eq(node1->data.key, -67);
     ck_assert_int_eq(node1 == NULL, false);
@@ -315,8 +347,10 @@ START_TEST(test_dll_delete_2)
     DoublyLinkedList* node2;
 
     *head = NULL;
-    node1 = dll_insert(head, -67);
-    node2 = dll_insert(head, 30);
+    reg->key = -67;
+    node1 = dll_insert(head, *reg);
+    reg->key = 30;
+    node2 = dll_insert(head, *reg);
 
     ck_assert_int_eq(node1->data.key, -67);
     ck_assert_int_eq(node1 == NULL, false);
@@ -353,7 +387,8 @@ START_TEST(test_dll_delete_3)
     DoublyLinkedList* node1;
 
     *head = NULL;
-    node1 = dll_insert(head, -67);
+    reg->key = -67;
+    node1 = dll_insert(head, *reg);
 
     ck_assert_int_eq((*head)->data.key, -67);
 
@@ -382,9 +417,12 @@ START_TEST(test_dll_delete_4)
     DoublyLinkedList* node3;
 
     *head = NULL;
-    node1 = dll_insert(head, 25);
-    node2 = dll_insert(head, 75);
-    node3 = dll_insert(head, 150);
+    reg->key = 25;
+    node1 = dll_insert(head, *reg);
+    reg->key = 75;
+    node2 = dll_insert(head, *reg);
+    reg->key = 150;    
+    node3 = dll_insert(head, *reg);
 
     ck_assert_int_eq((*head)->data.key, 150);
     ck_assert_int_eq((*head)->prev == NULL, true);
@@ -436,11 +474,16 @@ END_TEST
 START_TEST(test_dll_delete_5)
 {
     DoublyLinkedList* node;
+    DoublyLinkedList* node1;
+    DoublyLinkedList* node3;
 
     *head = NULL;
-    dll_insert(head, 25);
-    dll_insert(head, 75);
-    dll_insert(head, 150);
+    reg->key = 25;
+    node1 = dll_insert(head, *reg);
+    reg->key = 75;
+    dll_insert(head, *reg);
+    reg->key = 150;    
+    node3 = dll_insert(head, *reg);
 
     node = dll_search(head, 75);
 
@@ -458,6 +501,8 @@ START_TEST(test_dll_delete_5)
     ck_assert_int_eq((*head)->next->data.key, 25);
 
     free(node);
+    free(node1);
+    free(node3);
 }
 END_TEST
 
@@ -465,11 +510,16 @@ START_TEST(test_dll_delete_6)
 {
     DoublyLinkedList* node1;
     DoublyLinkedList* node2;
+    DoublyLinkedList* node3;
+
 
     *head = NULL;
-    dll_insert(head, 25);
-    dll_insert(head, 75);
-    dll_insert(head, 150);
+    reg->key = 25;
+    dll_insert(head, *reg);
+    reg->key = 75;
+    node3 = dll_insert(head, *reg);
+    reg->key = 150;    
+    dll_insert(head, *reg);
 
     node1 = dll_search(head, 150);
     dll_delete(head, node1);
@@ -480,6 +530,7 @@ START_TEST(test_dll_delete_6)
     ck_assert_int_eq((*head)->prev == NULL, true);
     ck_assert_int_eq((*head)->next == NULL, true);
 
+    free(node3);
     free(node2);
     free(node1);
 }

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -14,7 +14,7 @@ START_TEST(test_dll_insert_1)
     DoublyLinkedList* node1;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -150);
@@ -40,7 +40,7 @@ START_TEST(test_dll_insert_2)
     DoublyLinkedList* node2;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, 10);
@@ -83,7 +83,7 @@ START_TEST(test_dll_insert_3)
     DoublyLinkedList* node4;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -149,7 +149,7 @@ START_TEST(test_dll_search_1)
     DoublyLinkedList* node4;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -183,7 +183,7 @@ START_TEST(test_dll_search_2)
     DoublyLinkedList* node4;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, 23);
@@ -213,7 +213,7 @@ START_TEST(test_dll_search_3)
     DoublyLinkedList* node6;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -255,7 +255,7 @@ START_TEST(test_dll_search_4)
     DoublyLinkedList* node6;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -292,7 +292,7 @@ START_TEST(test_dll_delete_1)
     DoublyLinkedList* node2;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -335,7 +335,7 @@ START_TEST(test_dll_delete_2)
     DoublyLinkedList* node2;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -377,7 +377,7 @@ START_TEST(test_dll_delete_3)
     DoublyLinkedList* node1;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, -67);
@@ -410,7 +410,7 @@ START_TEST(test_dll_delete_4)
     DoublyLinkedList* node3;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     node1 = dll_insert(head, 25);
@@ -470,7 +470,7 @@ START_TEST(test_dll_delete_5)
     DoublyLinkedList* node;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     dll_insert(head, 25);
@@ -503,7 +503,7 @@ START_TEST(test_dll_delete_6)
     DoublyLinkedList* node2;
     DoublyLinkedList** head;
 
-    head = malloc(sizeof(DoublyLinkedList**));
+    head = malloc(sizeof(DoublyLinkedList*));
 
     *head = NULL;
     dll_insert(head, 25);

--- a/tests/test_queue.c
+++ b/tests/test_queue.c
@@ -5,7 +5,6 @@
 #include <queue.h>
 
 Queue* q;
-Register reg;
 Register* el;
 int i;
 
@@ -35,9 +34,9 @@ END_TEST
 
 START_TEST(test_init_queue_2)
 {
-    reg.key = 10;
+    el->key = 10;
     init_queue(q);
-    enqueue(q, reg);
+    enqueue(q, *el);
     init_queue(q);
 
     ck_assert_int_eq(q->head, 0);
@@ -47,7 +46,6 @@ END_TEST
 
 START_TEST(test_init_queue_3)
 {
-    reg.key = 10;
     init_queue(q);
     dequeue(q, el);
 
@@ -69,7 +67,7 @@ START_TEST(test_queue_empty_2)
     bool result;
 
     init_queue(q);
-    result = enqueue(q, reg);
+    result = enqueue(q, *el);
 
     ck_assert_int_eq(result, true);
     ck_assert_int_eq(queue_empty(q), false);
@@ -84,7 +82,7 @@ START_TEST(test_queue_empty_3)
 
     ck_assert_int_eq(queue_empty(q), true);
 
-    result1 = enqueue(q, reg);
+    result1 = enqueue(q, *el);
 
     ck_assert_int_eq(result1, true);
     ck_assert_int_eq(queue_empty(q), false);
@@ -107,12 +105,12 @@ START_TEST(test_queue_full_2)
 {
     bool result = true;
 
-    reg.key = -10;
+    el->key = -10;
     init_queue(q);
 
     for (i = 0; i < (MAX - 2); i++)
     {
-        result = result && enqueue(q, reg);
+        result = result && enqueue(q, *el);
     }
 
     ck_assert_int_eq(result, true);
@@ -124,20 +122,20 @@ START_TEST(test_queue_full_3)
 {
     bool result = true;
 
-    reg.key = -10;
+    el->key = -10;
     init_queue(q);
 
     /* Filling up the queue */
     for (i = 0; i < (MAX - 1); i++)
     {
-        result = result && enqueue(q, reg);
+        result = result && enqueue(q, *el);
     }
 
     ck_assert_int_eq(result, true);
     ck_assert_int_eq(queue_full(q), true);
 
     /* Queue overflow */
-    result = enqueue(q, reg);
+    result = enqueue(q, *el);
     ck_assert_int_eq(result, false);
     ck_assert_int_eq(queue_full(q), true);
 }
@@ -146,8 +144,8 @@ END_TEST
 START_TEST(test_enqueue_1)
 bool result;
 init_queue(q);
-reg.key = 8;
-result = enqueue(q, reg);
+el->key = 8;
+result = enqueue(q, *el);
 
 ck_assert_int_eq(result, true);
 ck_assert_int_eq(q->tail, 1);
@@ -157,10 +155,10 @@ END_TEST
 START_TEST(test_enqueue_2)
 bool result1, result2;
 init_queue(q);
-reg.key = 8;
-result1 = enqueue(q, reg);
-reg.key = -15;
-result2 = enqueue(q, reg);
+el->key = 8;
+result1 = enqueue(q, *el);
+el->key = -15;
+result2 = enqueue(q, *el);
 
 ck_assert_int_eq(result1, true);
 ck_assert_int_eq(result2, true);
@@ -182,8 +180,8 @@ START_TEST(test_dequeue_2)
 bool result;
 init_queue(q);
 
-reg.key = -247;
-enqueue(q, reg);
+el->key = -247;
+enqueue(q, *el);
 result = dequeue(q, el);
 
 ck_assert_int_eq(result, true);
@@ -194,8 +192,8 @@ START_TEST(test_dequeue_3)
 bool result;
 init_queue(q);
 
-reg.key = -247;
-enqueue(q, reg);
+el->key = -247;
+enqueue(q, *el);
 dequeue(q, el);
 result = dequeue(q, el); /* el is not overwritten */
 
@@ -208,19 +206,19 @@ init_queue(q);
 
 for (i = 0; i < 14; i++)
 {
-    enqueue(q, reg);
+    enqueue(q, *el);
 }
 
-reg.key = 15;
-enqueue(q, reg);
-reg.key = 6;
-enqueue(q, reg);
-reg.key = 9;
-enqueue(q, reg);
-reg.key = 8;
-enqueue(q, reg);
-reg.key = 4;
-enqueue(q, reg);
+el->key = 15;
+enqueue(q, *el);
+el->key = 6;
+enqueue(q, *el);
+el->key = 9;
+enqueue(q, *el);
+el->key = 8;
+enqueue(q, *el);
+el->key = 4;
+enqueue(q, *el);
 
 for (i = 0; i < 14; i++)
 {
@@ -242,31 +240,31 @@ init_queue(q);
 
 for (i = 0; i < 14; i++)
 {
-    enqueue(q, reg);
+    enqueue(q, *el);
 }
 
-reg.key = 15;
-enqueue(q, reg);
-reg.key = 6;
-enqueue(q, reg);
-reg.key = 9;
-enqueue(q, reg);
-reg.key = 8;
-enqueue(q, reg);
-reg.key = 4;
-enqueue(q, reg);
+el->key = 15;
+enqueue(q, *el);
+el->key = 6;
+enqueue(q, *el);
+el->key = 9;
+enqueue(q, *el);
+el->key = 8;
+enqueue(q, *el);
+el->key = 4;
+enqueue(q, *el);
 
 for (i = 0; i < 14; i++)
 {
     dequeue(q, el);
 }
 
-reg.key = 17;
-enqueue(q, reg);
-reg.key = 3;
-enqueue(q, reg);
-reg.key = 5;
-enqueue(q, reg);
+el->key = 17;
+enqueue(q, *el);
+el->key = 3;
+enqueue(q, *el);
+el->key = 5;
+enqueue(q, *el);
 dequeue(q, el);
 
 ck_assert_int_eq(q->A[14].key, 15); /* Has been removed */

--- a/tests/test_seq_list.c
+++ b/tests/test_seq_list.c
@@ -5,7 +5,7 @@
 #include <seq_list.h>
 
 SeqList* sl;
-Register reg;
+Register* reg;
 
 void setup(void);
 void teardown(void);
@@ -13,11 +13,13 @@ Suite *make_seq_list_suite(void);
 
 void setup(void)
 {
+    reg = malloc(sizeof(Register));
     sl = malloc(sizeof(SeqList));
 }
 
 void teardown(void)
 {
+    free(reg);
     free(sl);
 }
 
@@ -108,8 +110,8 @@ START_TEST(test_insert_elem_1)
 {
     init_seq_list(sl);
 
-    reg.key = 13;
-    bool result = insert_elem(sl, reg, 0);
+    reg->key = 13;
+    bool result = insert_elem(sl, *reg, 0);
 
     ck_assert_int_eq(result, true);
     ck_assert_int_eq(sl->nElem, 1);
@@ -121,11 +123,11 @@ START_TEST(test_insert_elem_2)
 {
     init_seq_list(sl);
 
-    reg.key = -8;
-    bool result1 = insert_elem(sl, reg, 0);
+    reg->key = -8;
+    bool result1 = insert_elem(sl, *reg, 0);
 
-    reg.key = 7;
-    bool result2 = insert_elem(sl, reg, 1);
+    reg->key = 7;
+    bool result2 = insert_elem(sl, *reg, 1);
 
     ck_assert_int_eq(result1, true);
     ck_assert_int_eq(result2, true);
@@ -139,11 +141,11 @@ START_TEST(test_insert_elem_3)
 {
     init_seq_list(sl);
 
-    reg.key = -8;
-    bool result1 = insert_elem(sl, reg, 0);
+    reg->key = -8;
+    bool result1 = insert_elem(sl, *reg, 0);
 
-    reg.key = 7;
-    bool result2 = insert_elem(sl, reg, 2);
+    reg->key = 7;
+    bool result2 = insert_elem(sl, *reg, 2);
 
     ck_assert_int_eq(result1, true);
     ck_assert_int_eq(result2, false);
@@ -156,8 +158,8 @@ START_TEST(test_insert_elem_4)
 {
     init_seq_list(sl);
 
-    reg.key = -8;
-    bool result = insert_elem(sl, reg, -1);
+    reg->key = -8;
+    bool result = insert_elem(sl, *reg, -1);
 
     ck_assert_int_eq(result, false);
     ck_assert_int_eq(sl->nElem, 0);
@@ -168,8 +170,8 @@ START_TEST(test_insert_sorted_1)
 {
     init_seq_list(sl);
 
-    reg.key = 13;
-    bool result = insert_sorted(sl, reg);
+    reg->key = 13;
+    bool result = insert_sorted(sl, *reg);
 
     ck_assert_int_eq(result, true);
     ck_assert_int_eq(sl->nElem, 1);
@@ -181,11 +183,11 @@ START_TEST(test_insert_sorted_2)
 {
     init_seq_list(sl);
 
-    reg.key = 7;
-    bool result2 = insert_sorted(sl, reg);
+    reg->key = 7;
+    bool result2 = insert_sorted(sl, *reg);
 
-    reg.key = -8;
-    bool result1 = insert_sorted(sl, reg);
+    reg->key = -8;
+    bool result1 = insert_sorted(sl, *reg);
 
     ck_assert_int_eq(result1, true);
     ck_assert_int_eq(result2, true);
@@ -199,11 +201,11 @@ START_TEST(test_insert_sorted_3)
 {
     init_seq_list(sl);
 
-    reg.key = -8;
-    bool result1 = insert_sorted(sl, reg);
+    reg->key = -8;
+    bool result1 = insert_sorted(sl, *reg);
 
-    reg.key = -10;
-    bool result2 = insert_sorted(sl, reg);
+    reg->key = -10;
+    bool result2 = insert_sorted(sl, *reg);
 
     ck_assert_int_eq(result1, true);
     ck_assert_int_eq(result2, true);
@@ -216,14 +218,14 @@ END_TEST
 START_TEST(test_insert_sorted_4)
 {
     init_seq_list(sl);
-    reg.key = 10;
-    bool result1 = insert_sorted(sl, reg);
+    reg->key = 10;
+    bool result1 = insert_sorted(sl, *reg);
 
-    reg.key = -8;
-    bool result2 = insert_sorted(sl, reg);
+    reg->key = -8;
+    bool result2 = insert_sorted(sl, *reg);
 
-    reg.key = 0;
-    bool result3 = insert_sorted(sl, reg);
+    reg->key = 0;
+    bool result3 = insert_sorted(sl, *reg);
 
     ck_assert_int_eq(result1, true);
     ck_assert_int_eq(result2, true);
@@ -367,7 +369,7 @@ START_TEST(test_remove_elem_1)
     sl->A[0].key = 20;
     sl->nElem = 1;
 
-    bool result = remove_elem(20, sl);
+    bool result = remove_elem(sl, 20);
 
     ck_assert_int_eq(result, true);
     ck_assert_int_eq(sl->nElem, 0);
@@ -381,7 +383,7 @@ START_TEST(test_remove_elem_2)
     sl->A[1].key = 1;
     sl->nElem = 2;
 
-    bool result = remove_elem(2, sl);
+    bool result = remove_elem(sl, 2);
 
     ck_assert_int_eq(result, false);
 }
@@ -396,7 +398,7 @@ START_TEST(test_remove_elem_3)
     sl->A[3].key = -3;
     sl->nElem = 4;
 
-    bool result = remove_elem(2, sl);
+    bool result = remove_elem(sl, 2);
 
     ck_assert_int_eq(result, true);
     ck_assert_int_eq(sl->nElem, 3);
@@ -415,7 +417,7 @@ START_TEST(test_remove_elem_4)
     sl->A[3].key = -2;
     sl->nElem = 4;
 
-    bool result = remove_elem(7, sl);
+    bool result = remove_elem(sl, 7);
 
     ck_assert_int_eq(result, true);
     ck_assert_int_eq(sl->nElem, 3);

--- a/tests/test_sll.c
+++ b/tests/test_sll.c
@@ -12,7 +12,7 @@ START_TEST(test_sll_insert_1)
     SinglyLinkedList** head;
     SinglyLinkedList* node1;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -37,7 +37,7 @@ START_TEST(test_sll_insert_2)
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -71,7 +71,7 @@ START_TEST(test_sll_insert_3)
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -116,7 +116,7 @@ START_TEST(test_sll_search_1)
     SinglyLinkedList** head;
     SinglyLinkedList* node1;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_search(head, 100);
@@ -137,7 +137,7 @@ START_TEST(test_sll_search_2)
     SinglyLinkedList* node1;
     SinglyLinkedList* retrieved;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -168,7 +168,7 @@ START_TEST(test_sll_search_3)
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -198,7 +198,7 @@ START_TEST(test_sll_search_4)
     SinglyLinkedList* node2;
     SinglyLinkedList* retrieved;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -238,7 +238,7 @@ START_TEST(test_sll_search_5)
     SinglyLinkedList* node2;
     SinglyLinkedList* retrieved;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -277,7 +277,7 @@ START_TEST(test_sll_search_6)
     SinglyLinkedList* node2;
     SinglyLinkedList* retrieved;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -315,7 +315,7 @@ START_TEST(test_sll_search_7)
     SinglyLinkedList* node4;
     SinglyLinkedList* retrieved;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -367,7 +367,7 @@ START_TEST(test_sll_search_8)
     SinglyLinkedList* node4;
     SinglyLinkedList* retrieved;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -424,7 +424,7 @@ START_TEST(test_sll_search_9)
     SinglyLinkedList* node4;
     SinglyLinkedList* retrieved;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -476,7 +476,7 @@ START_TEST(test_sll_delete_1)
     SinglyLinkedList** head;
     SinglyLinkedList* node1;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -506,7 +506,7 @@ START_TEST(test_sll_delete_2)
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -546,7 +546,7 @@ START_TEST(test_sll_delete_3)
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -586,7 +586,7 @@ START_TEST(test_sll_delete_4)
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -624,7 +624,7 @@ START_TEST(test_sll_delete_5)
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -664,7 +664,7 @@ START_TEST(test_sll_delete_6)
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -735,7 +735,7 @@ START_TEST(test_sll_delete_7)
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -806,7 +806,7 @@ START_TEST(test_sll_delete_8)
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -877,7 +877,7 @@ START_TEST(test_sll_delete_9)
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -948,7 +948,7 @@ START_TEST(test_sll_delete_10)
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -1017,7 +1017,7 @@ START_TEST(test_sll_delete_11)
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -1086,7 +1086,7 @@ START_TEST(test_sll_delete_12)
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
 
-    head = malloc(sizeof(SinglyLinkedList**));
+    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);

--- a/tests/test_sll.c
+++ b/tests/test_sll.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <sll.h>
 
+Register* reg;
 SinglyLinkedList** head;
 
 void setup(void);
@@ -13,11 +14,13 @@ Suite *make_sll_suite(void);
 
 void setup(void)
 {
+    reg = malloc(sizeof(Register));
     head = malloc(sizeof(SinglyLinkedList*));
 }
 
 void teardown(void)
 {
+    free(reg);
     free(head);
 }
 
@@ -26,7 +29,8 @@ START_TEST(test_sll_insert_1)
     SinglyLinkedList* node1;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -47,8 +51,10 @@ START_TEST(test_sll_insert_2)
     SinglyLinkedList* node2;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, 250);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = 250;
+    node2 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -77,10 +83,14 @@ START_TEST(test_sll_insert_3)
     SinglyLinkedList* node4;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -135,7 +145,8 @@ START_TEST(test_sll_search_2)
     SinglyLinkedList* retrieved;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
     retrieved = sll_search(head, 200);
 
     ck_assert_int_eq(head == NULL, false);
@@ -162,7 +173,8 @@ START_TEST(test_sll_search_3)
     SinglyLinkedList* node2;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
     node2 = sll_search(head, -35);
 
     ck_assert_int_eq(head == NULL, false);
@@ -188,8 +200,10 @@ START_TEST(test_sll_search_4)
     SinglyLinkedList* retrieved;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, 250);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = 250;
+    node2 = sll_insert(head, *reg);
     retrieved = sll_search(head, 200);
 
     ck_assert_int_eq(head == NULL, false);
@@ -224,8 +238,10 @@ START_TEST(test_sll_search_5)
     SinglyLinkedList* retrieved;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, 250);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = 250;
+    node2 = sll_insert(head, *reg);
     retrieved = sll_search(head, 250);
 
     ck_assert_int_eq(head == NULL, false);
@@ -259,8 +275,10 @@ START_TEST(test_sll_search_6)
     SinglyLinkedList* retrieved;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, 250);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = 250;
+    node2 = sll_insert(head, *reg);
     retrieved = sll_search(head, 0);
 
     ck_assert_int_eq(head == NULL, false);
@@ -293,10 +311,14 @@ START_TEST(test_sll_search_7)
     SinglyLinkedList* retrieved;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
     retrieved = sll_search(head, 10);
 
     ck_assert_int_eq(head == NULL, false);
@@ -341,10 +363,14 @@ START_TEST(test_sll_search_8)
     SinglyLinkedList* retrieved;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
     retrieved = sll_search(head, 33);
 
     ck_assert_int_eq(head == NULL, false);
@@ -394,10 +420,14 @@ START_TEST(test_sll_search_9)
     SinglyLinkedList* retrieved;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
     retrieved = sll_search(head, 200);
 
     ck_assert_int_eq(head == NULL, false);
@@ -442,7 +472,8 @@ START_TEST(test_sll_delete_1)
     SinglyLinkedList* node1;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -468,8 +499,10 @@ START_TEST(test_sll_delete_2)
     SinglyLinkedList* node2;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, 250);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = 250;
+    node2 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -504,8 +537,10 @@ START_TEST(test_sll_delete_3)
     SinglyLinkedList* node2;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, 250);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = 250;
+    node2 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -540,8 +575,10 @@ START_TEST(test_sll_delete_4)
     SinglyLinkedList* node2;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, 250);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = 250;
+    node2 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -574,8 +611,10 @@ START_TEST(test_sll_delete_5)
     SinglyLinkedList* node2;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, 250);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = 250;
+    node2 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -610,10 +649,14 @@ START_TEST(test_sll_delete_6)
     SinglyLinkedList* node4;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -677,10 +720,14 @@ START_TEST(test_sll_delete_7)
     SinglyLinkedList* node4;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -744,10 +791,14 @@ START_TEST(test_sll_delete_8)
     SinglyLinkedList* node4;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -811,10 +862,14 @@ START_TEST(test_sll_delete_9)
     SinglyLinkedList* node4;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -878,10 +933,14 @@ START_TEST(test_sll_delete_10)
     SinglyLinkedList* node4;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -943,10 +1002,14 @@ START_TEST(test_sll_delete_11)
     SinglyLinkedList* node4;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);
@@ -1008,10 +1071,14 @@ START_TEST(test_sll_delete_12)
     SinglyLinkedList* node4;
 
     *head = NULL;
-    node1 = sll_insert(head, 200);
-    node2 = sll_insert(head, -80);
-    node3 = sll_insert(head, 33);
-    node4 = sll_insert(head, -730);
+    reg->key = 200;
+    node1 = sll_insert(head, *reg);
+    reg->key = -80;
+    node2 = sll_insert(head, *reg);
+    reg->key = 33;
+    node3 = sll_insert(head, *reg);
+    reg->key = -730;
+    node4 = sll_insert(head, *reg);
 
     ck_assert_int_eq(head == NULL, false);
     ck_assert_int_eq((*head) == NULL, false);

--- a/tests/test_sll.c
+++ b/tests/test_sll.c
@@ -5,14 +5,25 @@
 #include <stdbool.h>
 #include <sll.h>
 
+SinglyLinkedList** head;
+
+void setup(void);
+void teardown(void);
 Suite *make_sll_suite(void);
+
+void setup(void)
+{
+    head = malloc(sizeof(SinglyLinkedList*));
+}
+
+void teardown(void)
+{
+    free(head);
+}
 
 START_TEST(test_sll_insert_1)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -27,17 +38,13 @@ START_TEST(test_sll_insert_1)
     ck_assert_int_eq(node1->data.key, 200);
 
     free(node1);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_insert_2)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -59,19 +66,15 @@ START_TEST(test_sll_insert_2)
 
     free(node1);
     free(node2);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_insert_3)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -107,16 +110,12 @@ START_TEST(test_sll_insert_3)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_search_1)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_search(head, 100);
@@ -127,17 +126,13 @@ START_TEST(test_sll_search_1)
     ck_assert_int_eq(node1 == (*head), true);
 
     free(node1);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_search_2)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* retrieved;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -158,17 +153,13 @@ START_TEST(test_sll_search_2)
     ck_assert_int_eq(retrieved == node1, true);
 
     free(node1);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_search_3)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -187,18 +178,14 @@ START_TEST(test_sll_search_3)
 
     free(node1);
     free(node2);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_search_4)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* retrieved;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -227,18 +214,14 @@ START_TEST(test_sll_search_4)
 
     free(node1);
     free(node2);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_search_5)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* retrieved;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -266,18 +249,14 @@ START_TEST(test_sll_search_5)
 
     free(node1);
     free(node2);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_search_6)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* retrieved;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -302,20 +281,16 @@ START_TEST(test_sll_search_6)
 
     free(node1);
     free(node2);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_search_7)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
     SinglyLinkedList* retrieved;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -354,20 +329,16 @@ START_TEST(test_sll_search_7)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_search_8)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
     SinglyLinkedList* retrieved;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -411,20 +382,16 @@ START_TEST(test_sll_search_8)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_search_9)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
     SinglyLinkedList* retrieved;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -467,16 +434,12 @@ START_TEST(test_sll_search_9)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_1)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -496,17 +459,13 @@ START_TEST(test_sll_delete_1)
     ck_assert_int_eq((*head) == NULL, true);
 
     free(node1);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_2)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -536,17 +495,13 @@ START_TEST(test_sll_delete_2)
 
     free(node1);
     free(node2);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_3)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -576,17 +531,13 @@ START_TEST(test_sll_delete_3)
 
     free(node1);
     free(node2);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_4)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -614,17 +565,13 @@ START_TEST(test_sll_delete_4)
 
     free(node1);
     free(node2);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_5)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -652,19 +599,15 @@ START_TEST(test_sll_delete_5)
 
     free(node1);
     free(node2);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_6)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -723,19 +666,15 @@ START_TEST(test_sll_delete_6)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_7)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -794,19 +733,15 @@ START_TEST(test_sll_delete_7)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_8)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -865,19 +800,15 @@ START_TEST(test_sll_delete_8)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_9)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -936,19 +867,15 @@ START_TEST(test_sll_delete_9)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_10)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -1005,19 +932,15 @@ START_TEST(test_sll_delete_10)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_11)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -1074,19 +997,15 @@ START_TEST(test_sll_delete_11)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
 START_TEST(test_sll_delete_12)
 {
-    SinglyLinkedList** head;
     SinglyLinkedList* node1;
     SinglyLinkedList* node2;
     SinglyLinkedList* node3;
     SinglyLinkedList* node4;
-
-    head = malloc(sizeof(SinglyLinkedList*));
 
     *head = NULL;
     node1 = sll_insert(head, 200);
@@ -1135,7 +1054,6 @@ START_TEST(test_sll_delete_12)
     free(node2);
     free(node3);
     free(node4);
-    free(head);
 }
 END_TEST
 
@@ -1148,6 +1066,8 @@ Suite *make_sll_suite(void)
 
     /* Creation test case */
     tc_core = tcase_create("Test Cases with no Setup/Teardown");
+
+    tcase_add_checked_fixture(tc_core, setup, teardown);
 
     tcase_add_test(tc_core, test_sll_insert_1);
     tcase_add_test(tc_core, test_sll_insert_2);    

--- a/tests/test_stack.c
+++ b/tests/test_stack.c
@@ -5,9 +5,8 @@
 #include <stack.h>
 
 Stack* stk;
-Register reg;
-Register* element1;
-Register* element2;
+Register* reg;
+
 int i;
 
 void setup(void);
@@ -16,16 +15,14 @@ Suite *make_stack_suite(void);
 
 void setup(void)
 {
+    reg = malloc(sizeof(Register));
     stk = malloc(sizeof(Stack));
-    element1 = malloc(sizeof(Register));
-    element2 = malloc(sizeof(Register));
 }
 
 void teardown(void)
 {
+    free(reg);
     free(stk);
-    free(element1);
-    free(element2);
 }
 
 START_TEST(test_init_stack_1)
@@ -58,9 +55,9 @@ END_TEST
 
 START_TEST(test_stack_empty_3)
 {
-    reg.key = 10;
+    reg->key = 10;
     init_stack(stk);
-    stk->A[0] = reg;
+    stk->A[0] = *reg;
     stk->top = 0;
     ck_assert_int_eq(stack_empty(stk), false);
 }
@@ -68,9 +65,9 @@ END_TEST
 
 START_TEST(test_stack_empty_4)
 {
-    reg.key = 10;
+    reg->key = 10;
     init_stack(stk);
-    stk->A[0] = reg;
+    stk->A[0] = *reg;
     stk->top = 0;
     init_stack(stk);
     ck_assert_int_eq(stack_empty(stk), true);
@@ -86,9 +83,9 @@ END_TEST
 
 START_TEST(test_stack_full_2)
 {
-    reg.key = -10;
+    reg->key = -10;
     init_stack(stk);
-    push(stk, reg);
+    push(stk, *reg);
     ck_assert_int_eq(stack_full(stk), false);
 }
 END_TEST
@@ -97,25 +94,25 @@ START_TEST(test_stack_full_3)
 {
     bool result = true;
 
-    reg.key = -10;
+    reg->key = -10;
     init_stack(stk);
 
     /* Filling up the stack */
     for (i = 0; i < MAX - 1; i++)
     {
-        result = result && push(stk, reg);
+        result = result && push(stk, *reg);
     }
 
     ck_assert_int_eq(result, true);
     ck_assert_int_eq(stack_full(stk), false);
 
     /* Last available position */
-    result = push(stk, reg);
+    result = push(stk, *reg);
     ck_assert_int_eq(result, true);
     ck_assert_int_eq(stack_full(stk), true);
 
     /* Stack overflow */
-    result = push(stk, reg);
+    result = push(stk, *reg);
     ck_assert_int_eq(result, false);
     ck_assert_int_eq(stack_full(stk), true);
 }
@@ -126,7 +123,7 @@ START_TEST(test_stack_pop_1)
     bool result;
 
     init_stack(stk);
-    result = pop(stk, element1);
+    result = pop(stk, reg);
 
     ck_assert_int_eq(result, false);
 }
@@ -137,40 +134,49 @@ START_TEST(test_stack_pop_2)
     bool result1, result2, result3;
 
     init_stack(stk);
-    result1 = pop(stk, element1); /* Doesn't write to pointer address*/
-    reg.key = 7;
-    push(stk, reg);
-    result2 = pop(stk, element1); /* Writes to pointer address*/
-    result3 = pop(stk, element1); /* Doesn't write to pointer address*/
+    result1 = pop(stk, reg); /* Doesn't write to pointer address*/
+    reg->key = 7;
+    push(stk, *reg);
+    result2 = pop(stk, reg); /* Writes to pointer address*/
+    result3 = pop(stk, reg); /* Doesn't write to pointer address*/
 
     ck_assert_int_eq(result1, false);
     ck_assert_int_eq(result2, true);
     ck_assert_int_eq(result3, false);
 
-    ck_assert_int_eq(element1->key, 7);
+    ck_assert_int_eq(reg->key, 7);
 }
 END_TEST
 
 START_TEST(test_stack_pop_3)
 {
+    Register* el1;
+    Register* el2;
+    
+    el1 = malloc(sizeof(Register));
+    el2 = malloc(sizeof(Register));
+
     bool result1, result2, result3;
 
     init_stack(stk);
-    reg.key = 7;
-    push(stk, reg);
-    reg.key = -5;
-    push(stk, reg);
+    reg->key = 7;
+    push(stk, *reg);
+    reg->key = -5;
+    push(stk, *reg);
 
-    result1 = pop(stk, element1);
-    result2 = pop(stk, element2);
-    result3 = pop(stk, element2);
+    result1 = pop(stk, el1);
+    result2 = pop(stk, el2);
+    result3 = pop(stk, el2);
 
     ck_assert_int_eq(result1, true);
     ck_assert_int_eq(result2, true);
     ck_assert_int_eq(result3, false);
 
-    ck_assert_int_eq(element1->key, -5);
-    ck_assert_int_eq(element2->key, 7);
+    ck_assert_int_eq(el1->key, -5);
+    ck_assert_int_eq(el2->key, 7);
+
+    free(el1);
+    free(el2);
 }
 END_TEST
 


### PR DESCRIPTION
# Fix memory allocation of pointers. Replace Key for Register as function parameter

## Description

Assign correct size to pointers on memory allocation. Replace Key for Register as function parameter to allow for changes in the Register struct without violating the lib's interface. Employ pointers in the unit tests to allow memory to be freed when no longer needed. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Existing unit tests still work

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules