### PR TITLE
Fix memory leak in test suites

### DIFF
--- a/tests/test_bst.c
+++ b/tests/test_bst.c
@@ -12588,6 +12588,8 @@ START_TEST(test_bst_tree_delete_6)
     ck_assert_int_eq(removed->right == node3, true);
     ck_assert_int_eq(removed->data.key, 15);
 
+    free(node5);
+    free(node4);
     free(node3);
     free(node2);
     free(node1);
@@ -12732,6 +12734,8 @@ START_TEST(test_bst_tree_delete_7)
     ck_assert_int_eq(removed->right == NULL, true);
     ck_assert_int_eq(removed->data.key, 5);
 
+    free(node5);
+    free(node4);
     free(node3);
     free(node2);
     free(node1);

--- a/tests/test_rbt.c
+++ b/tests/test_rbt.c
@@ -387,6 +387,7 @@ START_TEST(test_rbt_insert_1)
     ck_assert_int_eq((*root)->right->p == node2, true);
     ck_assert_int_eq((*root)->right == node1, true);
 
+    free(node3);
     free(node2);
     free(node1);
     free(nil);


### PR DESCRIPTION
# Fix memory leak in test suites

## Description
Apply valgrind on each test suite. Edit BST and RBT test suites to remove memory leaks.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Apply valgrind to the binary of each test suite 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules