### PR TITLE
Add algorithms for sorting in linear time

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,7 +52,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SIBYLLINE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
 # Show all warning messages
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -std=c89 -pedantic \
                    -Wmissing-prototypes -Wstrict-prototypes \
-                   -Wold-style-definition")
+                   -Wold-style-definition -lm")
 
 
 file(GLOB src ${SIBYLLINE_SRC_ROOT}/*.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SIBYLLINE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
 # Show all warning messages
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -std=c89 -pedantic \
                    -Wmissing-prototypes -Wstrict-prototypes \
-                   -Wold-style-definition -lm -ldl")
+                   -Wold-style-definition")
 
 file(GLOB src ${SIBYLLINE_SRC_ROOT}/*.c)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,7 @@ set(SIBYLLINE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
 # Show all warning messages
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -std=c89 -pedantic \
                    -Wmissing-prototypes -Wstrict-prototypes \
-                   -Wold-style-definition -lm")
-
+                   -Wold-style-definition -lm -ldl")
 
 file(GLOB src ${SIBYLLINE_SRC_ROOT}/*.c)
 

--- a/src/dll.c
+++ b/src/dll.c
@@ -31,6 +31,29 @@ DoublyLinkedList* dll_search(DoublyLinkedList** head, void* key,
   return node;
 }
 
+DoublyLinkedList* dll_get_nth(DoublyLinkedList** head, int n)
+{
+  int i;
+  DoublyLinkedList* current;
+
+  current = (*head);
+  if (n > -1)
+  {
+    i = 0;
+    while (current != NULL && i < n)
+    {
+      current = current->next;
+      i++;
+    } 
+  }
+  else
+  {
+    current = NULL;
+  }
+
+  return current;
+}
+
 void dll_delete(DoublyLinkedList** head, DoublyLinkedList* to_remove)
 {
   if (to_remove->prev != NULL)

--- a/src/dll.c
+++ b/src/dll.c
@@ -53,6 +53,30 @@ DoublyLinkedList* dll_get_nth(DoublyLinkedList** head, int n)
 
   return current;
 }
+DoublyLinkedList* dll_get_by_idx(DoublyLinkedList* curt, int curt_idx, int end)
+{
+  int i = curt_idx;
+  DoublyLinkedList* current = curt;
+
+  if (end > curt_idx)
+  {
+    while (current != NULL && i < end)
+    {
+      current = current->next;
+      i++;
+    } 
+  }
+  else if (end < curt_idx)
+  {
+    while (current != NULL && i > end)
+    {
+      current = current->prev;
+      i--;
+    } 
+  }
+
+  return current;
+}
 
 void dll_delete(DoublyLinkedList** head, DoublyLinkedList* to_remove)
 {

--- a/src/dll.c
+++ b/src/dll.c
@@ -38,18 +38,18 @@ DoublyLinkedList* dll_get_nth(DoublyLinkedList** head, int n)
 
   current = (*head);
   if (n > -1)
-  {
-    i = 0;
-    while (current != NULL && i < n)
     {
-      current = current->next;
-      i++;
-    } 
-  }
+      i = 0;
+      while (current != NULL && i < n)
+        {
+          current = current->next;
+          i++;
+        }
+    }
   else
-  {
-    current = NULL;
-  }
+    {
+      current = NULL;
+    }
 
   return current;
 }
@@ -59,21 +59,21 @@ DoublyLinkedList* dll_get_by_idx(DoublyLinkedList* curt, int curt_idx, int end)
   DoublyLinkedList* current = curt;
 
   if (end > curt_idx)
-  {
-    while (current != NULL && i < end)
     {
-      current = current->next;
-      i++;
-    } 
-  }
+      while (current != NULL && i < end)
+        {
+          current = current->next;
+          i++;
+        }
+    }
   else if (end < curt_idx)
-  {
-    while (current != NULL && i > end)
     {
-      current = current->prev;
-      i--;
-    } 
-  }
+      while (current != NULL && i > end)
+        {
+          current = current->prev;
+          i--;
+        }
+    }
 
   return current;
 }
@@ -99,9 +99,9 @@ void dll_free_list(DoublyLinkedList** head)
   DoublyLinkedList* current;
 
   while ((*head) != NULL)
-  {
-    current = (*head);
-    (*head) = (*head)->next;
-    free(current);
-  }
+    {
+      current = (*head);
+      (*head) = (*head)->next;
+      free(current);
+    }
 }

--- a/src/dll.c
+++ b/src/dll.c
@@ -93,3 +93,15 @@ void dll_delete(DoublyLinkedList** head, DoublyLinkedList* to_remove)
       (to_remove->next)->prev = to_remove->prev;
     }
 }
+
+void dll_free_list(DoublyLinkedList** head)
+{
+  DoublyLinkedList* current;
+
+  while ((*head) != NULL)
+  {
+    current = (*head);
+    (*head) = (*head)->next;
+    free(current);
+  }
+}

--- a/src/include/dll.h
+++ b/src/include/dll.h
@@ -63,7 +63,40 @@ DoublyLinkedList* dll_search(DoublyLinkedList** head, void* key,
  */
 void dll_delete(DoublyLinkedList** head, DoublyLinkedList* to_remove);
 
+/** @brief Retrieves nth node in Doubly Linked List.
+ *
+ * Searchs for element in Doubly Linked List by index. Starts search from
+ * Doubly Linked List's head. If nth element exists returns pointer to it
+ * if it doesn't exist returns @c NULL
+ *
+ * @param head Double pointer to head of Doubly Linked List.
+ * @param n Index of node to be retrieved.
+ * @return Pointer to retrieved node.
+ */
 DoublyLinkedList* dll_get_nth(DoublyLinkedList** head, int n);
+
+/** @brief Retrieves nth node in Doubly Linked List using a starting point.
+ *
+ * Searchs for element in Doubly Linked List by index. Starts search from
+ * Doubly Linked List's head. If nth element exists returns pointer to it
+ * if it doesn't exist returns @c NULL
+ *
+ * @param curt Pointer to node in Linked List used as search's starting point.
+ * @param curt_idx Index of node used as search's starting point.
+ * @param end Index of node to be retrieved.
+ * @return Pointer to retrieved node.
+ */
 DoublyLinkedList* dll_get_by_idx(DoublyLinkedList* curt, int curt_idx, int end);
+
+/** @brief Frees memory allocated for nodes in Doubly Linked List.
+ *
+ * Iterates over elements in Doubly Linked List and frees memory allocated
+ * for them. It's up to the user to free memory allocated to the double
+ * pointer (head).
+ *
+ * @param head Double pointer to head of Doubly Linked List.
+ * @return Void.
+ */
 void dll_free_list(DoublyLinkedList** head);
+
 #endif

--- a/src/include/dll.h
+++ b/src/include/dll.h
@@ -63,4 +63,6 @@ DoublyLinkedList* dll_search(DoublyLinkedList** head, void* key,
  */
 void dll_delete(DoublyLinkedList** head, DoublyLinkedList* to_remove);
 
+DoublyLinkedList* dll_get_nth(DoublyLinkedList** head, int n);
+
 #endif

--- a/src/include/dll.h
+++ b/src/include/dll.h
@@ -65,5 +65,5 @@ void dll_delete(DoublyLinkedList** head, DoublyLinkedList* to_remove);
 
 DoublyLinkedList* dll_get_nth(DoublyLinkedList** head, int n);
 DoublyLinkedList* dll_get_by_idx(DoublyLinkedList* curt, int curt_idx, int end);
-
+void dll_free_list(DoublyLinkedList** head);
 #endif

--- a/src/include/dll.h
+++ b/src/include/dll.h
@@ -64,5 +64,6 @@ DoublyLinkedList* dll_search(DoublyLinkedList** head, void* key,
 void dll_delete(DoublyLinkedList** head, DoublyLinkedList* to_remove);
 
 DoublyLinkedList* dll_get_nth(DoublyLinkedList** head, int n);
+DoublyLinkedList* dll_get_by_idx(DoublyLinkedList* curt, int curt_idx, int end);
 
 #endif

--- a/src/include/sort.h
+++ b/src/include/sort.h
@@ -9,6 +9,8 @@
 #ifndef SORT_H
 #define SORT_H
 
+#include <register.h>
+
 /** @brief Sorts given array via Insertion Sort procedure.
  *
  * Applies Insertion Sort procedure to sort array elements
@@ -20,6 +22,9 @@
  * @return Void
  */
 void insertion_sort(int array[], int start, int end);
+
+void insertion_sort_gnrc(Register array[], int start, int end,
+                         int (*compare)(void*, void*));
 
 /** @brief Combines two sorted sequences into a sorted one.
  *
@@ -168,5 +173,5 @@ void heap_sort(int array[], int length);
 void counting_sort(int array[], int* out, int length, int upper_limit);
 void counting_sort_by_nth_digit(int array[], int* out, int length, int n);
 void radix_sort(int array[], int* out, int length, int max_decimal_place);
-void bucket_sort(int array[], int length);
+void bucket_sort(Register array[], int length);
 #endif

--- a/src/include/sort.h
+++ b/src/include/sort.h
@@ -167,7 +167,6 @@ void heap_sort(int array[], int length);
 
 void counting_sort(int array[], int* out, int length, int upper_limit);
 void counting_sort_by_nth_digit(int array[], int* out, int length, int n);
-
 void radix_sort(int array[], int* out, int length, int max_decimal_place);
-
+void bucket_sort(int array[], int length);
 #endif

--- a/src/include/sort.h
+++ b/src/include/sort.h
@@ -24,6 +24,20 @@
  */
 void insertion_sort(int array[], int start, int end);
 
+/** @brief Sorts given array via Insertion Sort procedure.
+ *
+ * Applies Insertion Sort procedure to sort array elements in ascending
+ * order. The employed compare function must receive two void pointers
+ * as parameters and return an integer as result. If first parameter is
+ * bigger it should return 1, if first parameter is smaller it should
+ * return -1, if it's the same as the second parameter it should return 0.
+ *
+ * @param array Array of Registers to be sorted
+ * @param start Position of first array element to be sorted.
+ * @param end Position of last array element to be sorted.
+ * @param compare Pointer to function that compares two void pointers.
+ * @return Void
+ */
 void insertion_sort_gnrc(Register array[], int start, int end,
                          int (*compare)(void*, void*));
 
@@ -171,12 +185,89 @@ void bubble_sort(int array[], int start, int end);
  */
 void heap_sort(int array[], int length);
 
+/** @brief Sorts given array via Counting Sort procedure.
+ *
+ * Applies the Counting Sort procedure to sort all elements in array in
+ * ascending order. Counting sort assumes that each element is an integer
+ * in the range 0 to @c upper_limit. The employed compare function must
+ * receive two void pointers as parameters and return an integer as result.
+ * If first parameter is bigger it should return 1, if first parameter is
+ * smaller it should return -1, if it's the same as the second parameter
+ * it should return 0.
+ *
+ * @param array Array of integer numbers to be sorted.
+ * @param out Output array that will contain the sorted version.
+ * @param length Number of elements in array.
+ * @param upper_limit Upper bound for values in array.
+ * @return Void
+ */
 void counting_sort(int array[], int* out, int length, int upper_limit);
+
+/** @brief Sorts given array via Counting Sort based on nth decimal place.
+ *
+ * Applies the Counting Sort procedure to sort all elements in array in
+ * ascending order based on the nth decimal place of value of elements.
+ * Counting sort assumes that each element is an integer in the range
+ * 0 to @c upper_limit. The employed compare function must receive two
+ * void pointers as parameters and return an integer as result. If first
+ * parameter is bigger it should return 1, if first parameter is smaller
+ * it should return -1, if it's the same as the second parameter it should
+ * return 0.
+ *
+ * @param array Array of integer numbers to be sorted.
+ * @param out Output array that will contain the sorted version.
+ * @param length Number of elements in array.
+ * @param n Decimal place to be used by sorting procedure.
+ * @return Void
+ */
 void counting_sort_by_nth_digit(int array[], int* out, int length, int n);
+
+/** @brief Sorts given array via Radix Sort procedure.
+ *
+ * Applies the Radix Sort procedure to sort all elements in array in
+ * ascending order. Radix Sort expects a maximum number of decimal places
+ * in the given array elements.
+ *
+ * @param array Array of integer numbers to be sorted.
+ * @param out Output array that will contain the sorted version.
+ * @param length Number of elements in array.
+ * @param max_decimal_place Maximum number of decimal places in elements.
+ * @return Void
+ */
 void radix_sort(int array[], int* out, int length, int max_decimal_place);
 
+/** @brief Sorts Doubly Linked List via Insertion Sort procedure.
+ *
+ * Applies Insertion Sort procedure to sort elements in Doubly Linked List
+ * in ascending order. The employed compare function must receive two void
+ * pointers as parameters and return an integer as result. If first parameter
+ * is bigger it should return 1, if first parameter is smaller it should
+ * return -1, if it's the same as the second parameter it should return 0.
+ *
+ * @param head Double pointer to head of existing Doubly Linked List.
+ * @param start Position of first element in list to be sorted.
+ * @param end Position of last element in list to be sorted.
+ * @param compare Pointer to function that compares two void pointers.
+ * @return Void
+ */
 void insertion_sort_dll(DoublyLinkedList** head, int start, int end,
                         int (*compare)(void*, void*));
+
+/** @brief Sorts array of Registers via Bucket Sort procedure.
+ *
+ * Applies Insertion Sort procedure to sort elements in Doubly Linked List
+ * in ascending order. The employed compare function must receive two void
+ * pointers as parameters and return an integer as result. If first parameter
+ * is bigger it should return 1, if first parameter is smaller it should
+ * return -1, if it's the same as the second parameter it should return 0.
+ *
+ * @param array Array of Registers to be sorted
+ * @param length Number of elements in array.
+ * @param compare Pointer to function that multiplies the values of two
+ *  void pointers then floors the result.
+ * @param compare Pointer to function that compares two void pointers.
+ * @return Void
+ */
 void bucket_sort(Register array[], int length,
                  int (*mul_plus_floor)(int, void*),
                  int (*compare)(void*, void*));

--- a/src/include/sort.h
+++ b/src/include/sort.h
@@ -10,6 +10,7 @@
 #define SORT_H
 
 #include <register.h>
+#include <dll.h>
 
 /** @brief Sorts given array via Insertion Sort procedure.
  *
@@ -173,5 +174,8 @@ void heap_sort(int array[], int length);
 void counting_sort(int array[], int* out, int length, int upper_limit);
 void counting_sort_by_nth_digit(int array[], int* out, int length, int n);
 void radix_sort(int array[], int* out, int length, int max_decimal_place);
+
+void insertion_sort_dll(DoublyLinkedList** head, int start, int end,
+		                         int (*compare)(void*, void*));
 void bucket_sort(Register array[], int length);
 #endif

--- a/src/include/sort.h
+++ b/src/include/sort.h
@@ -165,4 +165,6 @@ void bubble_sort(int array[], int start, int end);
  */
 void heap_sort(int array[], int length);
 
+void counting_sort(int array[], int* out, int length, int upper_limit);
+
 #endif

--- a/src/include/sort.h
+++ b/src/include/sort.h
@@ -166,5 +166,6 @@ void bubble_sort(int array[], int start, int end);
 void heap_sort(int array[], int length);
 
 void counting_sort(int array[], int* out, int length, int upper_limit);
+void counting_sort_by_nth_digit(int array[], int* out, int length, int n);
 
 #endif

--- a/src/include/sort.h
+++ b/src/include/sort.h
@@ -9,8 +9,8 @@
 #ifndef SORT_H
 #define SORT_H
 
-#include <register.h>
 #include <dll.h>
+#include <register.h>
 
 /** @brief Sorts given array via Insertion Sort procedure.
  *
@@ -176,7 +176,9 @@ void counting_sort_by_nth_digit(int array[], int* out, int length, int n);
 void radix_sort(int array[], int* out, int length, int max_decimal_place);
 
 void insertion_sort_dll(DoublyLinkedList** head, int start, int end,
-		                         int (*compare)(void*, void*));
-void bucket_sort(Register array[], int length, int (*mul_plus_floor)(int, void*), int (*compare)(void*, void*));
+                        int (*compare)(void*, void*));
+void bucket_sort(Register array[], int length,
+                 int (*mul_plus_floor)(int, void*),
+                 int (*compare)(void*, void*));
 
 #endif

--- a/src/include/sort.h
+++ b/src/include/sort.h
@@ -168,4 +168,6 @@ void heap_sort(int array[], int length);
 void counting_sort(int array[], int* out, int length, int upper_limit);
 void counting_sort_by_nth_digit(int array[], int* out, int length, int n);
 
+void radix_sort(int array[], int* out, int length, int max_decimal_place);
+
 #endif

--- a/src/include/sort.h
+++ b/src/include/sort.h
@@ -177,5 +177,6 @@ void radix_sort(int array[], int* out, int length, int max_decimal_place);
 
 void insertion_sort_dll(DoublyLinkedList** head, int start, int end,
 		                         int (*compare)(void*, void*));
-void bucket_sort(Register array[], int length);
+void bucket_sort(Register array[], int length, int (*mul_plus_floor)(int, void*), int (*compare)(void*, void*));
+
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -45,4 +45,7 @@ int max(int array[], int start, int end);
  */
 int sample(int lower, int upper);
 
+int ipow(int base, int exp);
+int nth_digit(int number, int nth, int base);
+
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -45,8 +45,29 @@ int max(int array[], int start, int end);
  */
 int sample(int lower, int upper);
 
+/** @brief Calculates integer power for given base and exponent.
+ *
+ * Calculates integer power for given base and exponent. As an integer
+ * operation exponent cannot be a negative number.
+ *
+ * @param base Base for integer power.
+ * @param exp exponent for integer power.
+ * @return Integer Result of base ^ exponent .
+ */
 int ipow(int base, int exp);
 
+/** @brief Extracts nth digit of given number on given base.
+ *
+ * Gets the nth digit of given number on given base. If @c base is 10 then
+ * the nth digit correspond to the nth decimal place. If @c base 10 is used
+ * @c nth equals 1 extracts the units, @c nth equals 2 extracts the
+ * tenths and so forth.
+ *
+ * @param number Number to extract digit from.
+ * @param n Decimal place / digit to extract.
+ * @param base Base to consider to calculate nth digit.
+ * @return Nth digit of given number on given base.
+ */
 int nth_digit(int number, int nth, int base);
 
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -46,6 +46,7 @@ int max(int array[], int start, int end);
 int sample(int lower, int upper);
 
 int ipow(int base, int exp);
+
 int nth_digit(int number, int nth, int base);
 
 #endif

--- a/src/sort.c
+++ b/src/sort.c
@@ -378,20 +378,56 @@ void insertion_sort_dll(DoublyLinkedList** head, int start, int end,
     }
 }
 
-void bucket_sort(Register array[], int length)
+void bucket_sort(Register array[], int length, int (*mul_plus_floor)(int, void*), int (*compare)(void*, void*))
 {
-  int i;
+  int i, j, pos;
+  int* buckets_size; 
   DoublyLinkedList*** buckets;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node;
 
   buckets = malloc(length * sizeof(DoublyLinkedList**));
+  buckets_size = malloc(length * sizeof(int));
 
   for (i = 0; i < length; i++)
     {
-      (*buckets[i]) = NULL;
+      buckets[i] = malloc(sizeof(DoublyLinkedList*));
+      *buckets[i] = NULL;
+      buckets_size[i] = 0;
     }
 
   for (i = 0; i < length; i++)
     {
-      dll_insert(buckets[i], array[i]);
+      pos = mul_plus_floor(length, array[i].key);
+      dll_insert(buckets[pos], array[i]);
+      buckets_size[pos]++;
     }
+
+  for (i = 0; i < length; i++)
+    {
+      head = buckets[i];
+      insertion_sort_dll(head, 0, buckets_size[i] - 1, compare);
+    }
+
+  j = 0;
+  for (i = 0; i < length; i++)
+    {
+      head = buckets[i];
+      node = (*head);
+      while (node != NULL)
+      {
+        array[j] = node->data;
+	node = node->next;
+	j++;
+      }
+      dll_free_list(head);
+    }
+
+  for (i = 0; i < length; i++)
+  {
+      free(buckets[i]);
+  }
+
+  free(buckets_size);
+  free(buckets);
 }

--- a/src/sort.c
+++ b/src/sort.c
@@ -243,7 +243,7 @@ void counting_sort(int array[], int* out, int length, int upper_limit)
   int i;
   int* occ;
 
-  occ = malloc((upper_limit + 1) * sizeof(int)); /* MAKES VALGRIND FAIL */
+  occ = malloc((upper_limit + 1) * sizeof(int));
 
   for (i = 0; i <= upper_limit; i++)
     {
@@ -268,6 +268,45 @@ void counting_sort(int array[], int* out, int length, int upper_limit)
       out[occ[array[i]] - 1] = array[i];
       /* CAUSES SEGFAULT */ /* MAKES VALGRIND FAIL */
       occ[array[i]] = occ[array[i]] - 1;
+    }
+
+  free(occ);
+}
+
+/* will go from 0 to upper_limit (inclusive) */
+void counting_sort_by_nth_digit(int array[], int* out, int length, int n)
+{
+  int* occ;
+  int i, digit;
+  int upper_limit = 9;
+
+  occ = malloc((upper_limit + 1) * sizeof(int));
+
+  for (i = 0; i <= upper_limit; i++)
+    {
+      occ[i] = 0;
+    }
+
+  for (i = 0; i < length; i++)
+    {
+      digit = nth_digit(array[i], n, 10);
+      occ[digit] = occ[digit] + 1;
+    }
+  /* occ[0] contains how many times 0 occurs in array */
+
+  for (i = 1; i <= upper_limit; i++)
+    {
+      occ[i] = occ[i] + occ[i - 1];
+    }
+  /* occ[1] contains number of elements less than or equal to 1 in array */
+  /* occ[1] then represents where 1 should be at a sorted array */
+
+  for (i = length - 1; i > -1; i--)
+    {
+      digit = nth_digit(array[i], n, 10);
+      out[occ[digit] - 1] = array[i];
+      /* CAUSES SEGFAULT */ /* MAKES VALGRIND FAIL */
+      occ[digit] = occ[digit] - 1;
     }
 
   free(occ);

--- a/src/sort.c
+++ b/src/sort.c
@@ -1,12 +1,12 @@
+#include <dll.h>
+#include <heap.h>
 #include <limits.h>
 #include <malloc.h>
 #include <math.h>
+#include <sort.h>
 #include <stdlib.h>
 #include <string.h>
 #include <utils.h>
-#include <heap.h>
-#include <dll.h>
-#include <sort.h>
 
 #define INFINITY INT_MAX
 
@@ -331,7 +331,26 @@ void radix_sort(int array[], int* out, int length, int max_decimal_place)
   free(temp);
 }
 
-void bucket_sort(int array[], int length)
+void insertion_sort_gnrc(Register array[], int start, int end,
+                         int (*compare)(void*, void*))
+{
+  int j, i;
+  Register reg;
+
+  for (j = start + 1; j <= end; j++)
+    {
+      reg = array[j];
+      i = j - 1; /* last element of sorted deck */
+      while (i > (start - 1) && compare(array[i].key, reg.key) == 1)
+        {
+          array[i + 1] = array[i];
+          i = i - 1;
+        }
+      array[i + 1] = reg;
+    }
+}
+
+void bucket_sort(Register array[], int length)
 {
   int i;
   DoublyLinkedList*** buckets;
@@ -339,8 +358,12 @@ void bucket_sort(int array[], int length)
   buckets = malloc(length * sizeof(DoublyLinkedList**));
 
   for (i = 0; i < length; i++)
-  {
-    buckets[i] = NULL;
-  }
+    {
+      (*buckets[i]) = NULL;
+    }
 
+  for (i = 0; i < length; i++)
+    {
+      dll_insert(buckets[i], array[i]);
+    }
 }

--- a/src/sort.c
+++ b/src/sort.c
@@ -1,11 +1,12 @@
-#include <heap.h>
 #include <limits.h>
 #include <malloc.h>
 #include <math.h>
-#include <sort.h>
 #include <stdlib.h>
 #include <string.h>
 #include <utils.h>
+#include <heap.h>
+#include <dll.h>
+#include <sort.h>
 
 #define INFINITY INT_MAX
 
@@ -328,4 +329,18 @@ void radix_sort(int array[], int* out, int length, int max_decimal_place)
     }
 
   free(temp);
+}
+
+void bucket_sort(int array[], int length)
+{
+  int i;
+  DoublyLinkedList*** buckets;
+
+  buckets = malloc(length * sizeof(DoublyLinkedList**));
+
+  for (i = 0; i < length; i++)
+  {
+    buckets[i] = NULL;
+  }
+
 }

--- a/src/sort.c
+++ b/src/sort.c
@@ -1,10 +1,10 @@
-#include <assert.h>
 #include <heap.h>
 #include <limits.h>
 #include <malloc.h>
 #include <math.h>
 #include <sort.h>
 #include <stdlib.h>
+#include <string.h>
 #include <utils.h>
 
 #define INFINITY INT_MAX
@@ -266,7 +266,6 @@ void counting_sort(int array[], int* out, int length, int upper_limit)
   for (i = length - 1; i > -1; i--)
     {
       out[occ[array[i]] - 1] = array[i];
-      /* CAUSES SEGFAULT */ /* MAKES VALGRIND FAIL */
       occ[array[i]] = occ[array[i]] - 1;
     }
 
@@ -274,6 +273,7 @@ void counting_sort(int array[], int* out, int length, int upper_limit)
 }
 
 /* will go from 0 to upper_limit (inclusive) */
+/* n: which of n digits to consider */
 void counting_sort_by_nth_digit(int array[], int* out, int length, int n)
 {
   int* occ;
@@ -305,9 +305,27 @@ void counting_sort_by_nth_digit(int array[], int* out, int length, int n)
     {
       digit = nth_digit(array[i], n, 10);
       out[occ[digit] - 1] = array[i];
-      /* CAUSES SEGFAULT */ /* MAKES VALGRIND FAIL */
       occ[digit] = occ[digit] - 1;
     }
 
   free(occ);
+}
+
+void radix_sort(int array[], int* out, int length, int max_decimal_place)
+{
+  int i, size;
+  int* temp;
+
+  size = length * sizeof(int);
+  temp = malloc(size);
+
+  memcpy(temp, array, size);
+
+  for (i = 1; i <= max_decimal_place; i++)
+    {
+      counting_sort_by_nth_digit(temp, out, length, i);
+      memcpy(temp, out, size);
+    }
+
+  free(temp);
 }

--- a/src/sort.c
+++ b/src/sort.c
@@ -350,6 +350,34 @@ void insertion_sort_gnrc(Register array[], int start, int end,
     }
 }
 
+void insertion_sort_dll(DoublyLinkedList** head, int start, int end,
+                         int (*compare)(void*, void*))
+{
+  int j, i, k;
+  Register reg;
+  DoublyLinkedList* current;
+
+  k = start + 1;
+  current = dll_get_nth(head, k);
+
+  for (j = start + 1; j <= end; j++)
+    {
+      current = dll_get_by_idx(current, k, j);
+      reg = current->data;
+      k = j;
+
+      i = j - 1; /* last element of sorted deck */
+      while (i > (start - 1) &&
+             compare(dll_get_by_idx(current, k, i)->data.key, reg.key) == 1)
+        {
+	  dll_get_by_idx(current, k, i+1)->data = dll_get_by_idx(current, k, i)->data;
+          i = i - 1;
+        }
+
+      dll_get_by_idx(current, k, i+1)->data = reg;
+    }
+}
+
 void bucket_sort(Register array[], int length)
 {
   int i;

--- a/src/sort.c
+++ b/src/sort.c
@@ -351,7 +351,7 @@ void insertion_sort_gnrc(Register array[], int start, int end,
 }
 
 void insertion_sort_dll(DoublyLinkedList** head, int start, int end,
-                         int (*compare)(void*, void*))
+                        int (*compare)(void*, void*))
 {
   int j, i, k;
   Register reg;
@@ -370,18 +370,21 @@ void insertion_sort_dll(DoublyLinkedList** head, int start, int end,
       while (i > (start - 1) &&
              compare(dll_get_by_idx(current, k, i)->data.key, reg.key) == 1)
         {
-	  dll_get_by_idx(current, k, i+1)->data = dll_get_by_idx(current, k, i)->data;
+          dll_get_by_idx(current, k, i + 1)->data =
+              dll_get_by_idx(current, k, i)->data;
           i = i - 1;
         }
 
-      dll_get_by_idx(current, k, i+1)->data = reg;
+      dll_get_by_idx(current, k, i + 1)->data = reg;
     }
 }
 
-void bucket_sort(Register array[], int length, int (*mul_plus_floor)(int, void*), int (*compare)(void*, void*))
+void bucket_sort(Register array[], int length,
+                 int (*mul_plus_floor)(int, void*),
+                 int (*compare)(void*, void*))
 {
   int i, j, pos;
-  int* buckets_size; 
+  int* buckets_size;
   DoublyLinkedList*** buckets;
   DoublyLinkedList** head;
   DoublyLinkedList* node;
@@ -415,18 +418,18 @@ void bucket_sort(Register array[], int length, int (*mul_plus_floor)(int, void*)
       head = buckets[i];
       node = (*head);
       while (node != NULL)
-      {
-        array[j] = node->data;
-	node = node->next;
-	j++;
-      }
+        {
+          array[j] = node->data;
+          node = node->next;
+          j++;
+        }
       dll_free_list(head);
     }
 
   for (i = 0; i < length; i++)
-  {
+    {
       free(buckets[i]);
-  }
+    }
 
   free(buckets_size);
   free(buckets);

--- a/src/sort.c
+++ b/src/sort.c
@@ -266,7 +266,7 @@ void counting_sort(int array[], int* out, int length, int upper_limit)
   for (i = length - 1; i > -1; i--)
     {
       out[occ[array[i]] - 1] = array[i];
-          /* CAUSES SEGFAULT */ /* MAKES VALGRIND FAIL */
+      /* CAUSES SEGFAULT */ /* MAKES VALGRIND FAIL */
       occ[array[i]] = occ[array[i]] - 1;
     }
 

--- a/src/sort.c
+++ b/src/sort.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <heap.h>
 #include <limits.h>
 #include <malloc.h>
@@ -234,4 +235,40 @@ void heap_sort(int array[], int length)
       heap_size--;
       max_heapify(array, heap_size, 0);
     }
+}
+
+/* will go from 0 to upper_limit (inclusive) */
+void counting_sort(int array[], int* out, int length, int upper_limit)
+{
+  int i;
+  int* occ;
+
+  occ = malloc((upper_limit + 1) * sizeof(int)); /* MAKES VALGRIND FAIL */
+
+  for (i = 0; i <= upper_limit; i++)
+    {
+      occ[i] = 0;
+    }
+
+  for (i = 0; i < length; i++)
+    {
+      occ[array[i]] = occ[array[i]] + 1;
+    }
+  /* occ[0] contains how many times 0 occurs in array */
+
+  for (i = 1; i <= upper_limit; i++)
+    {
+      occ[i] = occ[i] + occ[i - 1];
+    }
+  /* occ[1] contains number of elements less than or equal to 1 in array */
+  /* occ[1] then represents where 1 should be at a sorted array */
+
+  for (i = length - 1; i > -1; i--)
+    {
+      out[occ[array[i]] - 1] = array[i];
+          /* CAUSES SEGFAULT */ /* MAKES VALGRIND FAIL */
+      occ[array[i]] = occ[array[i]] - 1;
+    }
+
+  free(occ);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -38,3 +38,24 @@ int sample(int lower, int upper)
 
   return num;
 }
+
+int ipow(int base, int exp)
+{
+  int result = 1;
+  for (;;)
+    {
+      if (exp & 1)
+        result *= base;
+      exp >>= 1;
+      if (!exp)
+        break;
+      base *= base;
+    }
+
+  return result;
+}
+
+int nth_digit(int number, int nth, int base)
+{
+  return (number / ipow(base, nth - 1)) % base;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ foreach(test_src_file ${test_src})
     # Since Check uses Threads to paralelize the tests, it's mandatory
     # add pthread as a dependency, alongside the Check libraries.
     add_executable(${test_name} ${test_src_file})
-    target_link_libraries(${test_name} sibylline ${CHECK_LIBRARIES} pthread)
+    target_link_libraries(${test_name} sibylline ${CHECK_LIBRARIES} pthread m)
 
     # Create testing target and redirect its output to `Testing` folder
     add_test(NAME ${test_name} COMMAND ${test_name} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Testing)

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -633,6 +633,338 @@ START_TEST(test_dll_delete_6)
 }
 END_TEST
 
+START_TEST(test_dll_get_nth_1)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+  retrieved = dll_get_nth(head, 0);
+
+  ck_assert_int_eq(retrieved == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, false);
+  ck_assert_int_eq(retrieved->prev == NULL, true);
+  ck_assert_int_eq(*((int*)retrieved->data.key), 30);
+  ck_assert_int_eq(*((int*)retrieved->next->data.key), -67);
+  ck_assert_int_eq(*((int*)retrieved->next->prev->data.key), 30);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_nth_2)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+
+  retrieved = dll_get_nth(head, 1);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), -67);
+  ck_assert_int_eq(retrieved == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, true);
+  ck_assert_int_eq(retrieved->prev == NULL, false);
+  ck_assert_int_eq(*((int*)retrieved->prev->next->data.key), -67);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_nth_3)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+
+  retrieved = dll_get_nth(head, -1);
+
+  ck_assert_int_eq(retrieved == NULL, true);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+
+START_TEST(test_dll_get_nth_4)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+
+  retrieved = dll_get_nth(head, 2);
+
+  ck_assert_int_eq(retrieved == NULL, true);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_nth_5)
+{
+  int k1;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)(*head)->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, true);
+
+  ck_assert_int_eq(*((int*)(*head)->data.key), -67);
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, true);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+
+  dll_delete(head, node1);
+
+  ck_assert_int_eq((*head) == NULL, true);
+
+  retrieved = dll_get_nth(head, 0);
+
+  ck_assert_int_eq(retrieved == NULL, true);
+
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_nth_6)
+{
+  int k1, k2, k3;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* retrieved;
+
+  k1 = 25;
+  k2 = 75;
+  k3 = 150;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+  reg->key = &k3;
+  node3 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)(*head)->data.key), 150);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 75);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node3->data.key), 150);
+  ck_assert_int_eq(node3->prev == NULL, true);
+  ck_assert_int_eq(node3->next == NULL, false);
+  ck_assert_int_eq(*((int*)node3->next->data.key), 75);
+  ck_assert_int_eq(*((int*)node3->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 75);
+  ck_assert_int_eq(node2->prev == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(*((int*)node2->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)node2->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node1->data.key), 25);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(*((int*)node1->prev->data.key), 75);
+  ck_assert_int_eq(*((int*)node1->prev->prev->data.key), 150);
+
+  retrieved = dll_get_nth(head, 2);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), 25);
+  ck_assert_int_eq(retrieved->prev == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, true);
+  ck_assert_int_eq(*((int*)retrieved->prev->data.key), 75);
+  ck_assert_int_eq(*((int*)retrieved->prev->prev->data.key), 150);
+
+  free(node3);
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_nth_7)
+{
+  float k1, k2, k3, k4;
+  DoublyLinkedList* node;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* retrieved;
+
+  k1 = 25.7;
+  k2 = 75.123;
+  k3 = 150.211;
+  k4 = 75.123;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  dll_insert(head, *reg);
+  reg->key = &k3;
+  node3 = dll_insert(head, *reg);
+
+  node = dll_search(head, &k4, compare);
+
+  ck_assert_float_eq(*((float*)(*head)->data.key), 150.211);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_float_eq(*((float*)(*head)->next->data.key), 75.123);
+  ck_assert_float_eq(*((float*)(*head)->next->next->data.key), 25.7);
+
+  dll_delete(head, node);
+
+  ck_assert_float_eq(*((float*)(*head)->data.key), 150.211);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_float_eq(*((float*)(*head)->next->data.key), 25.7);
+
+  retrieved = dll_get_nth(head, 1);
+
+  ck_assert_float_eq(*((float*)retrieved->data.key), 25.7);
+  ck_assert_int_eq(retrieved->prev == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, true);
+  ck_assert_float_eq(*((float*)retrieved->prev->data.key), 150.211);
+
+  free(node);
+  free(node1);
+  free(node3);
+}
+END_TEST
+
 Suite* make_test_suite(void)
 {
   Suite* s;
@@ -661,6 +993,15 @@ Suite* make_test_suite(void)
   tcase_add_test(tc_core, test_dll_delete_5);
   tcase_add_test(tc_core, test_dll_delete_6);
 
+
+  tcase_add_test(tc_core, test_dll_get_nth_1);
+  tcase_add_test(tc_core, test_dll_get_nth_2);
+  tcase_add_test(tc_core, test_dll_get_nth_3);
+  tcase_add_test(tc_core, test_dll_get_nth_4);
+  tcase_add_test(tc_core, test_dll_get_nth_5);
+  tcase_add_test(tc_core, test_dll_get_nth_6);
+  tcase_add_test(tc_core, test_dll_get_nth_7);
+  
   suite_add_tcase(s, tc_core);
 
   return s;

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -717,7 +717,6 @@ START_TEST(test_dll_get_nth_2)
   ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
   ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
 
-
   retrieved = dll_get_nth(head, 1);
 
   ck_assert_int_eq(*((int*)retrieved->data.key), -67);
@@ -766,7 +765,6 @@ START_TEST(test_dll_get_nth_3)
   ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
   ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
 
-
   retrieved = dll_get_nth(head, -1);
 
   ck_assert_int_eq(retrieved == NULL, true);
@@ -775,7 +773,6 @@ START_TEST(test_dll_get_nth_3)
   free(node1);
 }
 END_TEST
-
 
 START_TEST(test_dll_get_nth_4)
 {
@@ -811,7 +808,6 @@ START_TEST(test_dll_get_nth_4)
   ck_assert_int_eq(*((int*)(*head)->data.key), 30);
   ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
   ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
-
 
   retrieved = dll_get_nth(head, 2);
 
@@ -1645,7 +1641,6 @@ Suite* make_test_suite(void)
   tcase_add_test(tc_core, test_dll_delete_5);
   tcase_add_test(tc_core, test_dll_delete_6);
 
-
   tcase_add_test(tc_core, test_dll_get_nth_1);
   tcase_add_test(tc_core, test_dll_get_nth_2);
   tcase_add_test(tc_core, test_dll_get_nth_3);
@@ -1653,7 +1648,7 @@ Suite* make_test_suite(void)
   tcase_add_test(tc_core, test_dll_get_nth_5);
   tcase_add_test(tc_core, test_dll_get_nth_6);
   tcase_add_test(tc_core, test_dll_get_nth_7);
-  
+
   tcase_add_test(tc_core, test_dll_get_by_idx_1);
   tcase_add_test(tc_core, test_dll_get_by_idx_2);
   tcase_add_test(tc_core, test_dll_get_by_idx_3);
@@ -1664,7 +1659,7 @@ Suite* make_test_suite(void)
   tcase_add_test(tc_core, test_dll_get_by_idx_8);
   tcase_add_test(tc_core, test_dll_get_by_idx_9);
   tcase_add_test(tc_core, test_dll_get_by_idx_10);
-  
+
   suite_add_tcase(s, tc_core);
 
   return s;

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -1613,6 +1613,84 @@ START_TEST(test_dll_get_by_idx_10)
 }
 END_TEST
 
+START_TEST(test_dll_free_list_1)
+{
+  int k1, k2, k3, k4, k5, k6;
+
+  k1 = -67;
+  k2 = 30;
+  k3 = -12;
+  k4 = 0;
+  k5 = 20;
+  k6 = -189;
+
+  *head = NULL;
+  reg->key = &k1;
+  dll_insert(head, *reg);
+  reg->key = &k2;
+  dll_insert(head, *reg);
+  reg->key = &k3;
+  dll_insert(head, *reg);
+  reg->key = &k4;
+  dll_insert(head, *reg);
+  reg->key = &k5;
+  dll_insert(head, *reg);
+  reg->key = &k6;
+  dll_insert(head, *reg);
+
+  dll_free_list(head);
+}
+END_TEST
+
+START_TEST(test_dll_free_list_2)
+{
+  int k1, k2, k3, k4, k5;
+
+  k1 = 25;
+  k2 = 75;
+  k3 = 150;
+  k4 = 12;
+  k5 = 34;
+
+  *head = NULL;
+  reg->key = &k1;
+  dll_insert(head, *reg);
+  reg->key = &k2;
+  dll_insert(head, *reg);
+  reg->key = &k3;
+  dll_insert(head, *reg);
+  reg->key = &k4;
+  dll_insert(head, *reg);
+  reg->key = &k5;
+  dll_insert(head, *reg);
+
+  dll_free_list(head);
+}
+END_TEST
+
+START_TEST(test_dll_free_list_3)
+{
+  int k1, k2, k3, k4;
+
+  k1 = -67;
+  k2 = 30;
+  k3 = -12;
+  k4 = 0;
+
+  *head = NULL;
+  reg->key = &k1;
+  dll_insert(head, *reg);
+  reg->key = &k2;
+  dll_insert(head, *reg);
+  reg->key = &k3;
+  dll_insert(head, *reg);
+  reg->key = &k4;
+  dll_insert(head, *reg);
+
+  dll_free_list(head);
+}
+END_TEST
+
 Suite* make_test_suite(void)
 {
   Suite* s;
@@ -1659,6 +1737,10 @@ Suite* make_test_suite(void)
   tcase_add_test(tc_core, test_dll_get_by_idx_8);
   tcase_add_test(tc_core, test_dll_get_by_idx_9);
   tcase_add_test(tc_core, test_dll_get_by_idx_10);
+
+  tcase_add_test(tc_core, test_dll_free_list_1);
+  tcase_add_test(tc_core, test_dll_free_list_2);
+  tcase_add_test(tc_core, test_dll_free_list_3);
 
   suite_add_tcase(s, tc_core);
 

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -965,6 +965,658 @@ START_TEST(test_dll_get_nth_7)
 }
 END_TEST
 
+START_TEST(test_dll_get_by_idx_1)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+  retrieved = dll_get_by_idx(node2, 0, 1);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), -67);
+  ck_assert_int_eq(retrieved == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, true);
+  ck_assert_int_eq(retrieved->prev == NULL, false);
+  ck_assert_int_eq(*((int*)retrieved->prev->next->data.key), -67);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_by_idx_2)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+  retrieved = dll_get_by_idx(node1, 1, 0);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), 30);
+  ck_assert_int_eq(retrieved == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, false);
+  ck_assert_int_eq(retrieved->prev == NULL, true);
+  ck_assert_int_eq(*((int*)retrieved->next->prev->data.key), 30);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_by_idx_3)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+  retrieved = dll_get_by_idx(node1, 1, -1);
+
+  ck_assert_int_eq(retrieved == NULL, true);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_by_idx_4)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+  retrieved = dll_get_by_idx(node2, 0, 2);
+
+  ck_assert_int_eq(retrieved == NULL, true);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_by_idx_5)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+  retrieved = dll_get_by_idx(node1, 1, 1);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), -67);
+  ck_assert_int_eq(retrieved == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, true);
+  ck_assert_int_eq(retrieved->prev == NULL, false);
+  ck_assert_int_eq(*((int*)retrieved->prev->next->data.key), -67);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_by_idx_6)
+{
+  int k1, k2;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* retrieved;
+
+  k1 = -67;
+  k2 = 30;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)node1->data.key), -67);
+  ck_assert_int_eq(node1 == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(*((int*)node1->prev->next->data.key), -67);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 30);
+  ck_assert_int_eq(node2 == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(node2->prev == NULL, true);
+  ck_assert_int_eq(*((int*)node2->next->prev->data.key), 30);
+
+  ck_assert_int_eq((*head) == NULL, false);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 30);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -67);
+  ck_assert_int_eq(*((int*)(*head)->next->prev->data.key), 30);
+
+  retrieved = dll_get_by_idx(node2, 0, 0);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), 30);
+  ck_assert_int_eq(retrieved == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, false);
+  ck_assert_int_eq(retrieved->prev == NULL, true);
+  ck_assert_int_eq(*((int*)retrieved->next->prev->data.key), 30);
+
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_by_idx_7)
+{
+  int k1, k2, k3, k4, k5;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* retrieved;
+
+  k1 = 25;
+  k2 = 75;
+  k3 = 150;
+  k4 = 12;
+  k5 = 34;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+  reg->key = &k3;
+  node3 = dll_insert(head, *reg);
+  reg->key = &k4;
+  node4 = dll_insert(head, *reg);
+  reg->key = &k5;
+  node5 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)(*head)->data.key), 34);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 12);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node5->data.key), 34);
+  ck_assert_int_eq(node5->prev == NULL, true);
+  ck_assert_int_eq(node5->next == NULL, false);
+  ck_assert_int_eq(*((int*)node5->next->data.key), 12);
+  ck_assert_int_eq(*((int*)node5->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)node5->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)node5->next->next->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node4->data.key), 12);
+  ck_assert_int_eq(node4->prev == NULL, false);
+  ck_assert_int_eq(node4->next == NULL, false);
+  ck_assert_int_eq(*((int*)node4->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node4->next->data.key), 150);
+  ck_assert_int_eq(*((int*)node4->next->next->data.key), 75);
+
+  ck_assert_int_eq(*((int*)node3->data.key), 150);
+  ck_assert_int_eq(node3->prev == NULL, false);
+  ck_assert_int_eq(node3->next == NULL, false);
+  ck_assert_int_eq(*((int*)node3->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node3->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node3->next->data.key), 75);
+  ck_assert_int_eq(*((int*)node3->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 75);
+  ck_assert_int_eq(node2->prev == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(*((int*)node2->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node2->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node2->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)node2->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node1->data.key), 25);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(*((int*)node1->prev->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node1->prev->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node1->prev->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)node1->prev->data.key), 75);
+
+  retrieved = dll_get_by_idx(node3, 2, 0);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), 34);
+  ck_assert_int_eq(retrieved->prev == NULL, true);
+  ck_assert_int_eq(retrieved->next == NULL, false);
+  ck_assert_int_eq(*((int*)retrieved->next->data.key), 12);
+  ck_assert_int_eq(*((int*)retrieved->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)retrieved->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)retrieved->next->next->next->next->data.key), 25);
+
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_by_idx_8)
+{
+  int k1, k2, k3, k4, k5;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* retrieved;
+
+  k1 = 25;
+  k2 = 75;
+  k3 = 150;
+  k4 = 12;
+  k5 = 34;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+  reg->key = &k3;
+  node3 = dll_insert(head, *reg);
+  reg->key = &k4;
+  node4 = dll_insert(head, *reg);
+  reg->key = &k5;
+  node5 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)(*head)->data.key), 34);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 12);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node5->data.key), 34);
+  ck_assert_int_eq(node5->prev == NULL, true);
+  ck_assert_int_eq(node5->next == NULL, false);
+  ck_assert_int_eq(*((int*)node5->next->data.key), 12);
+  ck_assert_int_eq(*((int*)node5->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)node5->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)node5->next->next->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node4->data.key), 12);
+  ck_assert_int_eq(node4->prev == NULL, false);
+  ck_assert_int_eq(node4->next == NULL, false);
+  ck_assert_int_eq(*((int*)node4->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node4->next->data.key), 150);
+  ck_assert_int_eq(*((int*)node4->next->next->data.key), 75);
+
+  ck_assert_int_eq(*((int*)node3->data.key), 150);
+  ck_assert_int_eq(node3->prev == NULL, false);
+  ck_assert_int_eq(node3->next == NULL, false);
+  ck_assert_int_eq(*((int*)node3->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node3->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node3->next->data.key), 75);
+  ck_assert_int_eq(*((int*)node3->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 75);
+  ck_assert_int_eq(node2->prev == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(*((int*)node2->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node2->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node2->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)node2->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node1->data.key), 25);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(*((int*)node1->prev->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node1->prev->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node1->prev->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)node1->prev->data.key), 75);
+
+  retrieved = dll_get_by_idx(node3, 2, 4);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), 25);
+  ck_assert_int_eq(retrieved->prev == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, true);
+  ck_assert_int_eq(*((int*)retrieved->prev->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)retrieved->prev->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)retrieved->prev->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)retrieved->prev->data.key), 75);
+
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_by_idx_9)
+{
+  int k1, k2, k3, k4, k5;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* retrieved;
+
+  k1 = 25;
+  k2 = 75;
+  k3 = 150;
+  k4 = 12;
+  k5 = 34;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+  reg->key = &k3;
+  node3 = dll_insert(head, *reg);
+  reg->key = &k4;
+  node4 = dll_insert(head, *reg);
+  reg->key = &k5;
+  node5 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)(*head)->data.key), 34);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 12);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node5->data.key), 34);
+  ck_assert_int_eq(node5->prev == NULL, true);
+  ck_assert_int_eq(node5->next == NULL, false);
+  ck_assert_int_eq(*((int*)node5->next->data.key), 12);
+  ck_assert_int_eq(*((int*)node5->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)node5->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)node5->next->next->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node4->data.key), 12);
+  ck_assert_int_eq(node4->prev == NULL, false);
+  ck_assert_int_eq(node4->next == NULL, false);
+  ck_assert_int_eq(*((int*)node4->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node4->next->data.key), 150);
+  ck_assert_int_eq(*((int*)node4->next->next->data.key), 75);
+
+  ck_assert_int_eq(*((int*)node3->data.key), 150);
+  ck_assert_int_eq(node3->prev == NULL, false);
+  ck_assert_int_eq(node3->next == NULL, false);
+  ck_assert_int_eq(*((int*)node3->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node3->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node3->next->data.key), 75);
+  ck_assert_int_eq(*((int*)node3->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 75);
+  ck_assert_int_eq(node2->prev == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(*((int*)node2->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node2->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node2->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)node2->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node1->data.key), 25);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(*((int*)node1->prev->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node1->prev->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node1->prev->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)node1->prev->data.key), 75);
+
+  retrieved = dll_get_by_idx(node5, 0, 4);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), 25);
+  ck_assert_int_eq(retrieved->prev == NULL, false);
+  ck_assert_int_eq(retrieved->next == NULL, true);
+  ck_assert_int_eq(*((int*)retrieved->prev->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)retrieved->prev->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)retrieved->prev->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)retrieved->prev->data.key), 75);
+
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+}
+END_TEST
+
+START_TEST(test_dll_get_by_idx_10)
+{
+  int k1, k2, k3, k4, k5;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* retrieved;
+
+  k1 = 25;
+  k2 = 75;
+  k3 = 150;
+  k4 = 12;
+  k5 = 34;
+
+  *head = NULL;
+  reg->key = &k1;
+  node1 = dll_insert(head, *reg);
+  reg->key = &k2;
+  node2 = dll_insert(head, *reg);
+  reg->key = &k3;
+  node3 = dll_insert(head, *reg);
+  reg->key = &k4;
+  node4 = dll_insert(head, *reg);
+  reg->key = &k5;
+  node5 = dll_insert(head, *reg);
+
+  ck_assert_int_eq(*((int*)(*head)->data.key), 34);
+  ck_assert_int_eq((*head)->prev == NULL, true);
+  ck_assert_int_eq((*head)->next == NULL, false);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 12);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node5->data.key), 34);
+  ck_assert_int_eq(node5->prev == NULL, true);
+  ck_assert_int_eq(node5->next == NULL, false);
+  ck_assert_int_eq(*((int*)node5->next->data.key), 12);
+  ck_assert_int_eq(*((int*)node5->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)node5->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)node5->next->next->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node4->data.key), 12);
+  ck_assert_int_eq(node4->prev == NULL, false);
+  ck_assert_int_eq(node4->next == NULL, false);
+  ck_assert_int_eq(*((int*)node4->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node4->next->data.key), 150);
+  ck_assert_int_eq(*((int*)node4->next->next->data.key), 75);
+
+  ck_assert_int_eq(*((int*)node3->data.key), 150);
+  ck_assert_int_eq(node3->prev == NULL, false);
+  ck_assert_int_eq(node3->next == NULL, false);
+  ck_assert_int_eq(*((int*)node3->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node3->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node3->next->data.key), 75);
+  ck_assert_int_eq(*((int*)node3->next->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node2->data.key), 75);
+  ck_assert_int_eq(node2->prev == NULL, false);
+  ck_assert_int_eq(node2->next == NULL, false);
+  ck_assert_int_eq(*((int*)node2->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node2->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node2->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)node2->next->data.key), 25);
+
+  ck_assert_int_eq(*((int*)node1->data.key), 25);
+  ck_assert_int_eq(node1->prev == NULL, false);
+  ck_assert_int_eq(node1->next == NULL, true);
+  ck_assert_int_eq(*((int*)node1->prev->prev->prev->prev->data.key), 34);
+  ck_assert_int_eq(*((int*)node1->prev->prev->prev->data.key), 12);
+  ck_assert_int_eq(*((int*)node1->prev->prev->data.key), 150);
+  ck_assert_int_eq(*((int*)node1->prev->data.key), 75);
+
+  retrieved = dll_get_by_idx(node1, 4, 0);
+
+  ck_assert_int_eq(*((int*)retrieved->data.key), 34);
+  ck_assert_int_eq(retrieved->prev == NULL, true);
+  ck_assert_int_eq(retrieved->next == NULL, false);
+  ck_assert_int_eq(*((int*)retrieved->next->data.key), 12);
+  ck_assert_int_eq(*((int*)retrieved->next->next->data.key), 150);
+  ck_assert_int_eq(*((int*)retrieved->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int*)retrieved->next->next->next->next->data.key), 25);
+
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+}
+END_TEST
+
 Suite* make_test_suite(void)
 {
   Suite* s;
@@ -1001,6 +1653,17 @@ Suite* make_test_suite(void)
   tcase_add_test(tc_core, test_dll_get_nth_5);
   tcase_add_test(tc_core, test_dll_get_nth_6);
   tcase_add_test(tc_core, test_dll_get_nth_7);
+  
+  tcase_add_test(tc_core, test_dll_get_by_idx_1);
+  tcase_add_test(tc_core, test_dll_get_by_idx_2);
+  tcase_add_test(tc_core, test_dll_get_by_idx_3);
+  tcase_add_test(tc_core, test_dll_get_by_idx_4);
+  tcase_add_test(tc_core, test_dll_get_by_idx_5);
+  tcase_add_test(tc_core, test_dll_get_by_idx_6);
+  tcase_add_test(tc_core, test_dll_get_by_idx_7);
+  tcase_add_test(tc_core, test_dll_get_by_idx_8);
+  tcase_add_test(tc_core, test_dll_get_by_idx_9);
+  tcase_add_test(tc_core, test_dll_get_by_idx_10);
   
   suite_add_tcase(s, tc_core);
 

--- a/tests/test_heap.c
+++ b/tests/test_heap.c
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-Suite *make_test_suite(void);
+Suite* make_test_suite(void);
 
 START_TEST(test_max_heapify_1)
 {
@@ -344,10 +344,10 @@ START_TEST(test_build_max_heap_8)
 }
 END_TEST
 
-Suite *make_test_suite(void)
+Suite* make_test_suite(void)
 {
-  Suite *s;
-  TCase *tc_core;
+  Suite* s;
+  TCase* tc_core;
 
   s = suite_create("Stack Creation Test Suite");
 
@@ -382,7 +382,7 @@ Suite *make_test_suite(void)
 int main(void)
 {
   int number_failed;
-  SRunner *sr;
+  SRunner* sr;
 
   sr = srunner_create(make_test_suite());
   srunner_set_fork_status(sr, CK_NOFORK);

--- a/tests/test_queue.c
+++ b/tests/test_queue.c
@@ -4,20 +4,20 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-Queue *q;
-Register *el;
+Queue* q;
+Register* el;
 int i;
 
 void setup(void);
 void teardown(void);
-Suite *make_test_suite(void);
-int compare(void *key1, void *key2);
+Suite* make_test_suite(void);
+int compare(void* key1, void* key2);
 
-int compare(void *key1, void *key2)
+int compare(void* key1, void* key2)
 {
   int result;
-  int k1 = *((int *)key1);
-  int k2 = *((int *)key2);
+  int k1 = *((int*)key1);
+  int k2 = *((int*)key2);
 
   if (k1 > k2)
     {
@@ -186,7 +186,7 @@ START_TEST(test_enqueue_1)
 
   ck_assert_int_eq(result, true);
   ck_assert_int_eq(q->tail, 1);
-  ck_assert_int_eq(*((int *)q->A[(q->head)].key), 8);
+  ck_assert_int_eq(*((int*)q->A[(q->head)].key), 8);
 }
 END_TEST
 
@@ -208,8 +208,8 @@ START_TEST(test_enqueue_2)
   ck_assert_int_eq(result2, true);
 
   ck_assert_int_eq(q->tail, 2);
-  ck_assert_int_eq(*((int *)q->A[(q->tail - 1)].key), -15);
-  ck_assert_int_eq(*((int *)q->A[(q->head)].key), 8);
+  ck_assert_int_eq(*((int*)q->A[(q->tail - 1)].key), -15);
+  ck_assert_int_eq(*((int*)q->A[(q->head)].key), 8);
 }
 END_TEST
 
@@ -237,7 +237,7 @@ START_TEST(test_dequeue_2)
   result = dequeue(q, el);
 
   ck_assert_int_eq(result, true);
-  ck_assert_int_eq(*((int *)el->key), -247);
+  ck_assert_int_eq(*((int*)el->key), -247);
 }
 END_TEST
 
@@ -255,7 +255,7 @@ START_TEST(test_dequeue_3)
   result = dequeue(q, el); /* el is not overwritten */
 
   ck_assert_int_eq(result, false);
-  ck_assert_int_eq(*((int *)el->key), -247);
+  ck_assert_int_eq(*((int*)el->key), -247);
 }
 END_TEST
 
@@ -292,11 +292,11 @@ START_TEST(test_recreate_1)
       dequeue(q, el);
     }
 
-  ck_assert_int_eq(*((int *)q->A[14].key), 15);
-  ck_assert_int_eq(*((int *)q->A[15].key), 6);
-  ck_assert_int_eq(*((int *)q->A[16].key), 9);
-  ck_assert_int_eq(*((int *)q->A[17].key), 8);
-  ck_assert_int_eq(*((int *)q->A[18].key), 4);
+  ck_assert_int_eq(*((int*)q->A[14].key), 15);
+  ck_assert_int_eq(*((int*)q->A[15].key), 6);
+  ck_assert_int_eq(*((int*)q->A[16].key), 9);
+  ck_assert_int_eq(*((int*)q->A[17].key), 8);
+  ck_assert_int_eq(*((int*)q->A[18].key), 4);
 
   ck_assert_int_eq(q->tail, 19);
   ck_assert_int_eq(q->head, 14);
@@ -346,27 +346,27 @@ START_TEST(test_recreate_2)
   enqueue(q, *el);
   dequeue(q, el);
 
-  ck_assert_int_eq(*((int *)q->A[14].key), 15); /* Has been removed */
-  ck_assert_int_eq(*((int *)q->A[15].key), 6);
-  ck_assert_int_eq(*((int *)q->A[16].key), 9);
-  ck_assert_int_eq(*((int *)q->A[17].key), 8);
-  ck_assert_int_eq(*((int *)q->A[18].key), 4);
-  ck_assert_int_eq(*((int *)q->A[19].key), 17);
-  ck_assert_int_eq(*((int *)q->A[0].key), 3);
-  ck_assert_int_eq(*((int *)q->A[1].key), 5);
+  ck_assert_int_eq(*((int*)q->A[14].key), 15); /* Has been removed */
+  ck_assert_int_eq(*((int*)q->A[15].key), 6);
+  ck_assert_int_eq(*((int*)q->A[16].key), 9);
+  ck_assert_int_eq(*((int*)q->A[17].key), 8);
+  ck_assert_int_eq(*((int*)q->A[18].key), 4);
+  ck_assert_int_eq(*((int*)q->A[19].key), 17);
+  ck_assert_int_eq(*((int*)q->A[0].key), 3);
+  ck_assert_int_eq(*((int*)q->A[1].key), 5);
 
   ck_assert_int_eq(q->tail, 2);
   ck_assert_int_eq(q->head, 15);
 
-  ck_assert_int_eq(*((int *)q->A[q->head].key), 6);
-  ck_assert_int_eq(*((int *)q->A[q->tail - 1].key), 5);
+  ck_assert_int_eq(*((int*)q->A[q->head].key), 6);
+  ck_assert_int_eq(*((int*)q->A[q->tail - 1].key), 5);
 }
 END_TEST
 
-Suite *make_test_suite(void)
+Suite* make_test_suite(void)
 {
-  Suite *s;
-  TCase *tc_core;
+  Suite* s;
+  TCase* tc_core;
 
   s = suite_create("Queue Test Suite");
 
@@ -405,7 +405,7 @@ Suite *make_test_suite(void)
 int main(void)
 {
   int number_failed;
-  SRunner *sr;
+  SRunner* sr;
 
   sr = srunner_create(make_test_suite());
   srunner_set_fork_status(sr, CK_NOFORK);

--- a/tests/test_seq_list.c
+++ b/tests/test_seq_list.c
@@ -4,19 +4,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-SeqList *sl;
-Register *reg;
+SeqList* sl;
+Register* reg;
 
 void setup(void);
 void teardown(void);
-Suite *make_test_suite(void);
-int compare(void *key1, void *key2);
+Suite* make_test_suite(void);
+int compare(void* key1, void* key2);
 
-int compare(void *key1, void *key2)
+int compare(void* key1, void* key2)
 {
   int result;
-  int k1 = *((int *)key1);
-  int k2 = *((int *)key2);
+  int k1 = *((int*)key1);
+  int k2 = *((int*)key2);
 
   if (k1 > k2)
     {
@@ -142,7 +142,7 @@ START_TEST(test_insert_elem_1)
 
   ck_assert_int_eq(result, true);
   ck_assert_int_eq(sl->nElem, 1);
-  ck_assert_int_eq(*((int *)sl->A[0].key), 13);
+  ck_assert_int_eq(*((int*)sl->A[0].key), 13);
 }
 END_TEST
 
@@ -166,8 +166,8 @@ START_TEST(test_insert_elem_2)
   ck_assert_int_eq(result1, true);
   ck_assert_int_eq(result2, true);
   ck_assert_int_eq(sl->nElem, 2);
-  ck_assert_int_eq(*((int *)sl->A[0].key), -8);
-  ck_assert_int_eq(*((int *)sl->A[1].key), 7);
+  ck_assert_int_eq(*((int*)sl->A[0].key), -8);
+  ck_assert_int_eq(*((int*)sl->A[1].key), 7);
 }
 END_TEST
 
@@ -191,7 +191,7 @@ START_TEST(test_insert_elem_3)
   ck_assert_int_eq(result1, true);
   ck_assert_int_eq(result2, false);
   ck_assert_int_eq(sl->nElem, 1);
-  ck_assert_int_eq(*((int *)sl->A[0].key), -8);
+  ck_assert_int_eq(*((int*)sl->A[0].key), -8);
 }
 END_TEST
 
@@ -226,7 +226,7 @@ START_TEST(test_insert_sorted_1)
 
   ck_assert_int_eq(result, true);
   ck_assert_int_eq(sl->nElem, 1);
-  ck_assert_int_eq(*((int *)sl->A[0].key), 13);
+  ck_assert_int_eq(*((int*)sl->A[0].key), 13);
 }
 END_TEST
 
@@ -250,8 +250,8 @@ START_TEST(test_insert_sorted_2)
   ck_assert_int_eq(result1, true);
   ck_assert_int_eq(result2, true);
   ck_assert_int_eq(sl->nElem, 2);
-  ck_assert_int_eq(*((int *)sl->A[0].key), -8);
-  ck_assert_int_eq(*((int *)sl->A[1].key), 7);
+  ck_assert_int_eq(*((int*)sl->A[0].key), -8);
+  ck_assert_int_eq(*((int*)sl->A[1].key), 7);
 }
 END_TEST
 
@@ -275,8 +275,8 @@ START_TEST(test_insert_sorted_3)
   ck_assert_int_eq(result1, true);
   ck_assert_int_eq(result2, true);
   ck_assert_int_eq(sl->nElem, 2);
-  ck_assert_int_eq(*((int *)sl->A[0].key), -10);
-  ck_assert_int_eq(*((int *)sl->A[1].key), -8);
+  ck_assert_int_eq(*((int*)sl->A[0].key), -10);
+  ck_assert_int_eq(*((int*)sl->A[1].key), -8);
 }
 END_TEST
 
@@ -306,9 +306,9 @@ START_TEST(test_insert_sorted_4)
   ck_assert_int_eq(result2, true);
   ck_assert_int_eq(result3, true);
   ck_assert_int_eq(sl->nElem, 3);
-  ck_assert_int_eq(*((int *)sl->A[0].key), -8);
-  ck_assert_int_eq(*((int *)sl->A[1].key), 0);
-  ck_assert_int_eq(*((int *)sl->A[2].key), 10);
+  ck_assert_int_eq(*((int*)sl->A[0].key), -8);
+  ck_assert_int_eq(*((int*)sl->A[1].key), 0);
+  ck_assert_int_eq(*((int*)sl->A[2].key), 10);
 }
 END_TEST
 
@@ -557,9 +557,9 @@ START_TEST(test_remove_elem_3)
 
   ck_assert_int_eq(result, true);
   ck_assert_int_eq(sl->nElem, 3);
-  ck_assert_int_eq(*((int *)sl->A[0].key), 0);
-  ck_assert_int_eq(*((int *)sl->A[1].key), -1);
-  ck_assert_int_eq(*((int *)sl->A[2].key), -3);
+  ck_assert_int_eq(*((int*)sl->A[0].key), 0);
+  ck_assert_int_eq(*((int*)sl->A[1].key), -1);
+  ck_assert_int_eq(*((int*)sl->A[2].key), -3);
 }
 END_TEST
 
@@ -584,16 +584,16 @@ START_TEST(test_remove_elem_4)
 
   ck_assert_int_eq(result, true);
   ck_assert_int_eq(sl->nElem, 3);
-  ck_assert_int_eq(*((int *)sl->A[0].key), 1);
-  ck_assert_int_eq(*((int *)sl->A[1].key), 7);
-  ck_assert_int_eq(*((int *)sl->A[2].key), -2);
+  ck_assert_int_eq(*((int*)sl->A[0].key), 1);
+  ck_assert_int_eq(*((int*)sl->A[1].key), 7);
+  ck_assert_int_eq(*((int*)sl->A[2].key), -2);
 }
 END_TEST
 
-Suite *make_test_suite(void)
+Suite* make_test_suite(void)
 {
-  Suite *s;
-  TCase *tc_core;
+  Suite* s;
+  TCase* tc_core;
 
   s = suite_create("SeqList Creation Test Suite");
 
@@ -654,7 +654,7 @@ Suite *make_test_suite(void)
 int main(void)
 {
   int number_failed;
-  SRunner *sr;
+  SRunner* sr;
 
   sr = srunner_create(make_test_suite());
   srunner_set_fork_status(sr, CK_NOFORK);

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -4554,6 +4554,1182 @@ START_TEST(test_insertion_sort_gnrc_16)
 }
 END_TEST
 
+START_TEST(test_insertion_sort_dll_1)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+
+  int k1, k2, k3, k4, k5, k6;
+  int start = 0;
+  int end = 5;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 5;
+  k2 = 2;
+  k3 = 4;
+  k4 = 6;
+  k5 = 1;
+  k6 = 3;
+
+  *head = NULL;
+  reg.key = &k1;
+  node1 = dll_insert(head, reg);
+  reg.key = &k2;
+  node2 = dll_insert(head, reg);
+  reg.key = &k3;
+  node3 = dll_insert(head, reg);
+  reg.key = &k4;
+  node4 = dll_insert(head, reg);
+  reg.key = &k5;
+  node5 = dll_insert(head, reg);
+  reg.key = &k6;
+  node6 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 1);
+  
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 6); 
+
+  free(node1);
+  free(node2);
+  free(node3);
+  free(node4);
+  free(node5);
+  free(node6);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_2)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+
+  int k1 = 5;
+  int start = 0;
+  int end = 0;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  *head = NULL;
+  reg.key = &k1;
+  node1 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 5);
+  ck_assert_int_eq(*((int *)node1->data.key), 5);
+
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_3)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  DoublyLinkedList* node9;
+  DoublyLinkedList* node10;
+  DoublyLinkedList* node11;
+
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11;
+  int start = 0;
+  int end = 10;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = -10;
+  k2 = 15;
+  k3 = -5;
+  k4 = -20;
+  k5 = 50;
+  k6 = 0;
+  k7 = 100;
+  k8 = 75;
+  k9 = 30;
+  k10 = 200;
+  k11 = -200;
+
+  *head = NULL;
+  reg.key = &k1;
+  node1 = dll_insert(head, reg);
+  reg.key = &k2;
+  node2 = dll_insert(head, reg);
+  reg.key = &k3;
+  node3 = dll_insert(head, reg);
+  reg.key = &k4;
+  node4 = dll_insert(head, reg);
+  reg.key = &k5;
+  node5 = dll_insert(head, reg);
+  reg.key = &k6;
+  node6 = dll_insert(head, reg);
+  reg.key = &k7;
+  node7 = dll_insert(head, reg);
+  reg.key = &k8;
+  node8 = dll_insert(head, reg);
+  reg.key = &k9;
+  node9 = dll_insert(head, reg);
+  reg.key = &k10;
+  node10 = dll_insert(head, reg);
+  reg.key = &k11;
+  node11 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), -200);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), -20);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -10);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 0);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 15);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 30);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 50);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 100);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 200);
+
+  free(node11);
+  free(node10);
+  free(node9);
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_4)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  DoublyLinkedList* node9;
+  DoublyLinkedList* node10;
+  
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  int start = 0;
+  int end = 9;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 0;
+  k2 = 1;
+  k3 = 2;
+  k4 = 3;
+  k5 = 4;
+  k6 = 5;
+  k7 = 6;
+  k8 = 7;
+  k9 = 8;
+  k10 = 9;
+
+  *head = NULL;
+  reg.key = &k1;
+  node1 = dll_insert(head, reg);
+  reg.key = &k2;
+  node2 = dll_insert(head, reg);
+  reg.key = &k3;
+  node3 = dll_insert(head, reg);
+  reg.key = &k4;
+  node4 = dll_insert(head, reg);
+  reg.key = &k5;
+  node5 = dll_insert(head, reg);
+  reg.key = &k6;
+  node6 = dll_insert(head, reg);
+  reg.key = &k7;
+  node7 = dll_insert(head, reg);
+  reg.key = &k8;
+  node8 = dll_insert(head, reg);
+  reg.key = &k9;
+  node9 = dll_insert(head, reg);
+  reg.key = &k10;
+  node10 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 8);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 9);
+
+  free(node10);
+  free(node9);
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_5)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  DoublyLinkedList* node9;
+  DoublyLinkedList* node10; 
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  
+  int start = 0;
+  int end = 9;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 9;
+  k2 = 8;
+  k3 = 7;
+  k4 = 6;
+  k5 = 5;
+  k6 = 4;
+  k7 = 3;
+  k8 = 2;
+  k9 = 1;
+  k10 = 0;
+
+  *head = NULL;
+  reg.key = &k1;
+  node1 = dll_insert(head, reg);
+  reg.key = &k2;
+  node2 = dll_insert(head, reg);
+  reg.key = &k3;
+  node3 = dll_insert(head, reg);
+  reg.key = &k4;
+  node4 = dll_insert(head, reg);
+  reg.key = &k5;
+  node5 = dll_insert(head, reg);
+  reg.key = &k6;
+  node6 = dll_insert(head, reg);
+  reg.key = &k7;
+  node7 = dll_insert(head, reg);
+  reg.key = &k8;
+  node8 = dll_insert(head, reg);
+  reg.key = &k9;
+  node9 = dll_insert(head, reg);
+  reg.key = &k10;
+  node10 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 8);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 9);
+
+  free(node10);
+  free(node9);
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_6)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  int k1, k2, k3, k4, k5, k6, k7, k8;
+  
+  int start = 2;
+  int end = 7;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 2;
+  k2 = 4;
+  k3 = 1;
+  k4 = 5;
+  k5 = 7;
+  k6 = 2;
+  k7 = 3;
+  k8 = 6;
+
+  *head = NULL;
+  reg.key = &k8; /* we put in reverse order */
+  node1 = dll_insert(head, reg);
+  reg.key = &k7; /* because the dll pushes nodes */
+  node2 = dll_insert(head, reg);
+  reg.key = &k6;
+  node3 = dll_insert(head, reg);
+  reg.key = &k5;
+  node4 = dll_insert(head, reg);
+  reg.key = &k4;
+  node5 = dll_insert(head, reg);
+  reg.key = &k3;
+  node6 = dll_insert(head, reg);
+  reg.key = &k2;
+  node7 = dll_insert(head, reg);
+  reg.key = &k1;
+  node8 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 1);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
+
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_7)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  int k1, k2, k3, k4, k5, k6, k7, k8;
+  
+  int start = 0;
+  int end = 5;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 2;
+  k2 = 4;
+  k3 = 5;
+  k4 = 1;
+  k5 = 2;
+  k6 = 3;
+  k7 = 7;
+  k8 = 6;
+
+  *head = NULL;
+  reg.key = &k8; /* we put in reverse order */
+  node1 = dll_insert(head, reg);
+  reg.key = &k7; /* because the dll pushes nodes */
+  node2 = dll_insert(head, reg);
+  reg.key = &k6;
+  node3 = dll_insert(head, reg);
+  reg.key = &k5;
+  node4 = dll_insert(head, reg);
+  reg.key = &k4;
+  node5 = dll_insert(head, reg);
+  reg.key = &k3;
+  node6 = dll_insert(head, reg);
+  reg.key = &k2;
+  node7 = dll_insert(head, reg);
+  reg.key = &k1;
+  node8 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 1);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 6);
+
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_8)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  int k1, k2, k3, k4, k5, k6, k7, k8;
+  
+  int start = 2;
+  int end = 5;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 2;
+  k2 = 4;
+  k3 = 1;
+  k4 = 5;
+  k5 = 2;
+  k6 = 3;
+  k7 = 7;
+  k8 = 6;
+
+  *head = NULL;
+  reg.key = &k8; /* we put in reverse order */
+  node1 = dll_insert(head, reg);
+  reg.key = &k7; /* because the dll pushes nodes */
+  node2 = dll_insert(head, reg);
+  reg.key = &k6;
+  node3 = dll_insert(head, reg);
+  reg.key = &k5;
+  node4 = dll_insert(head, reg);
+  reg.key = &k4;
+  node5 = dll_insert(head, reg);
+  reg.key = &k3;
+  node6 = dll_insert(head, reg);
+  reg.key = &k2;
+  node7 = dll_insert(head, reg);
+  reg.key = &k1;
+  node8 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 1);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 6);
+
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_9)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  DoublyLinkedList* node9;
+  DoublyLinkedList* node10;
+  DoublyLinkedList* node11;
+  DoublyLinkedList* node12;
+  DoublyLinkedList* node13;
+  DoublyLinkedList* node14;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14;
+
+  int start = 0;
+  int end = 13;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 0;
+  k2 = 2;
+  k3 = 3;
+  k4 = 4;
+  k5 = 55;
+  k6 = 300;
+  k7 = 700;
+  k8 = -200;
+  k9 = -100;
+  k10 = -80;
+  k11 = -7;
+  k12 = 30;
+  k13 = 150;
+  k14 = 570;
+
+  *head = NULL;
+  reg.key = &k14; /* we put in reverse order */
+  node1 = dll_insert(head, reg);
+  reg.key = &k13; /* because the dll pushes nodes */
+  node2 = dll_insert(head, reg);
+  reg.key = &k12;
+  node3 = dll_insert(head, reg);
+  reg.key = &k11;
+  node4 = dll_insert(head, reg);
+  reg.key = &k10;
+  node5 = dll_insert(head, reg);
+  reg.key = &k9;
+  node6 = dll_insert(head, reg);
+  reg.key = &k8;
+  node7 = dll_insert(head, reg);
+  reg.key = &k7;
+  node8 = dll_insert(head, reg);
+  reg.key = &k6;
+  node9 = dll_insert(head, reg);
+  reg.key = &k5;
+  node10 = dll_insert(head, reg);
+  reg.key = &k4;
+  node11 = dll_insert(head, reg);
+  reg.key = &k3;
+  node12 = dll_insert(head, reg);
+  reg.key = &k2;
+  node13 = dll_insert(head, reg);
+  reg.key = &k1;
+  node14 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), -200);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), -100);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -80);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -7);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 0);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 30);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 55);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 150);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->data.key), 300);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->next->data.key), 570);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->next->next->data.key), 700);
+
+  free(node14);
+  free(node13);
+  free(node12);
+  free(node11);
+  free(node10);
+  free(node9);
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_10)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  DoublyLinkedList* node9;
+  DoublyLinkedList* node10;
+  DoublyLinkedList* node11;
+  DoublyLinkedList* node12;
+  DoublyLinkedList* node13;
+  DoublyLinkedList* node14;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14;
+
+  int start = 2;
+  int end = 11;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 0;
+  k2 = 2;
+  k3 = 3;
+  k4 = 4;
+  k5 = 55;
+  k6 = 300;
+  k7 = 700;
+  k8 = -200;
+  k9 = -100;
+  k10 = -80;
+  k11 = -7;
+  k12 = 30;
+  k13 = 150;
+  k14 = 570;
+
+  *head = NULL;
+  reg.key = &k14; /* we put in reverse order */
+  node1 = dll_insert(head, reg);
+  reg.key = &k13; /* because the dll pushes nodes */
+  node2 = dll_insert(head, reg);
+  reg.key = &k12;
+  node3 = dll_insert(head, reg);
+  reg.key = &k11;
+  node4 = dll_insert(head, reg);
+  reg.key = &k10;
+  node5 = dll_insert(head, reg);
+  reg.key = &k9;
+  node6 = dll_insert(head, reg);
+  reg.key = &k8;
+  node7 = dll_insert(head, reg);
+  reg.key = &k7;
+  node8 = dll_insert(head, reg);
+  reg.key = &k6;
+  node9 = dll_insert(head, reg);
+  reg.key = &k5;
+  node10 = dll_insert(head, reg);
+  reg.key = &k4;
+  node11 = dll_insert(head, reg);
+  reg.key = &k3;
+  node12 = dll_insert(head, reg);
+  reg.key = &k2;
+  node13 = dll_insert(head, reg);
+  reg.key = &k1;
+  node14 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -200);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -100);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), -80);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), -7);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 30);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 55);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 300);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->data.key), 700);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->next->data.key), 150);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->next->next->data.key), 570);
+
+  free(node14);
+  free(node13);
+  free(node12);
+  free(node11);
+  free(node10);
+  free(node9);
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_11)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  DoublyLinkedList* node9;
+  DoublyLinkedList* node10;
+  DoublyLinkedList* node11;
+  DoublyLinkedList* node12;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12;
+
+  int start = 0;
+  int end = 11;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 3;
+  k2 = 15;
+  k3 = 20;
+  k4 = 30;
+  k5 = 50;
+  k6 = 75;
+  k7 = -75;
+  k8 = -50;
+  k9 = -30;
+  k10 = -20;
+  k11 = -15;
+  k12 = -3;
+
+  *head = NULL;
+  reg.key = &k12; /* we put in reverse order */
+  node1 = dll_insert(head, reg);
+  reg.key = &k11; /* because the dll pushes nodes */
+  node2 = dll_insert(head, reg);
+  reg.key = &k10;
+  node3 = dll_insert(head, reg);
+  reg.key = &k9;
+  node4 = dll_insert(head, reg);
+  reg.key = &k8;
+  node5 = dll_insert(head, reg);
+  reg.key = &k7;
+  node6 = dll_insert(head, reg);
+  reg.key = &k6;
+  node7 = dll_insert(head, reg);
+  reg.key = &k5;
+  node8 = dll_insert(head, reg);
+  reg.key = &k4;
+  node9 = dll_insert(head, reg);
+  reg.key = &k3;
+  node10 = dll_insert(head, reg);
+  reg.key = &k2;
+  node11 = dll_insert(head, reg);
+  reg.key = &k1;
+  node12 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), -75);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), -50);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -30);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -20);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), -15);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), -3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 15);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 20);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 30);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 50);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->data.key), 75);
+  
+  free(node12);
+  free(node11);
+  free(node10);
+  free(node9);
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_12)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  int k1, k2, k3, k4, k5, k6;
+
+  int start = 0;
+  int end = 5;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 5;
+  k2 = 2;
+  k3 = 4;
+  k4 = 6;
+  k5 = 1;
+  k6 = 3;
+
+  *head = NULL;
+  reg.key = &k6; /* we put in reverse order */
+  node1 = dll_insert(head, reg);
+  reg.key = &k5; /* because the dll pushes nodes */
+  node2 = dll_insert(head, reg);
+  reg.key = &k4;
+  node3 = dll_insert(head, reg);
+  reg.key = &k3;
+  node4 = dll_insert(head, reg);
+  reg.key = &k2;
+  node5 = dll_insert(head, reg);
+  reg.key = &k1;
+  node6 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 1);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 6);
+  
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_13)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  int k1;
+  int start = 0;
+  int end = 0;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 5;
+
+  *head = NULL;
+  reg.key = &k1;
+  node1 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 5);
+
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_14)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  DoublyLinkedList* node9;
+  DoublyLinkedList* node10;
+  DoublyLinkedList* node11;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11;
+
+  int start = 0;
+  int end = 10;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = -10;
+  k2 = 15;
+  k3 = -5;
+  k4 = -20;
+  k5 = 50;
+  k6 = 0;
+  k7 = 100;
+  k8 = 75;
+  k9 = 30;
+  k10 = 200;
+  k11 = -200;
+
+  *head = NULL;
+  reg.key = &k1;
+  node1 = dll_insert(head, reg);
+  reg.key = &k2;
+  node2 = dll_insert(head, reg);
+  reg.key = &k3;
+  node3 = dll_insert(head, reg);
+  reg.key = &k4;
+  node4 = dll_insert(head, reg);
+  reg.key = &k5;
+  node5 = dll_insert(head, reg);
+  reg.key = &k6;
+  node6 = dll_insert(head, reg);
+  reg.key = &k7;
+  node7 = dll_insert(head, reg);
+  reg.key = &k8;
+  node8 = dll_insert(head, reg);
+  reg.key = &k9;
+  node9 = dll_insert(head, reg);
+  reg.key = &k10;
+  node10 = dll_insert(head, reg);
+  reg.key = &k11;
+  node11 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), -200);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), -20);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -10);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 0);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 15);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 30);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 50);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 75);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 100);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 200);
+
+  free(node11);
+  free(node10);
+  free(node9);
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_15)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  DoublyLinkedList* node9;
+  DoublyLinkedList* node10; 
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+
+  int start = 0;
+  int end = 9;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 0;
+  k2 = 1;
+  k3 = 2;
+  k4 = 3;
+  k5 = 4;
+  k6 = 5;
+  k7 = 6;
+  k8 = 7;
+  k9 = 8;
+  k10 = 9;
+
+  *head = NULL;
+  reg.key = &k1;
+  node1 = dll_insert(head, reg);
+  reg.key = &k2;
+  node2 = dll_insert(head, reg);
+  reg.key = &k3;
+  node3 = dll_insert(head, reg);
+  reg.key = &k4;
+  node4 = dll_insert(head, reg);
+  reg.key = &k5;
+  node5 = dll_insert(head, reg);
+  reg.key = &k6;
+  node6 = dll_insert(head, reg);
+  reg.key = &k7;
+  node7 = dll_insert(head, reg);
+  reg.key = &k8;
+  node8 = dll_insert(head, reg);
+  reg.key = &k9;
+  node9 = dll_insert(head, reg);
+  reg.key = &k10;
+  node10 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 8);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 9);
+
+  free(node10);
+  free(node9);
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_dll_16)
+{
+  Register reg;
+  DoublyLinkedList** head;
+  DoublyLinkedList* node1;
+  DoublyLinkedList* node2;
+  DoublyLinkedList* node3;
+  DoublyLinkedList* node4;
+  DoublyLinkedList* node5;
+  DoublyLinkedList* node6;
+  DoublyLinkedList* node7;
+  DoublyLinkedList* node8;
+  DoublyLinkedList* node9;
+  DoublyLinkedList* node10; 
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+
+  int start = 0;
+  int end = 9;
+
+  head = malloc(sizeof(DoublyLinkedList*));
+
+  k1 = 9;
+  k2 = 8;
+  k3 = 7;
+  k4 = 6;
+  k5 = 5;
+  k6 = 4;
+  k7 = 3;
+  k8 = 2;
+  k9 = 1;
+  k10 = 0;
+
+  *head = NULL;
+  reg.key = &k1;
+  node1 = dll_insert(head, reg);
+  reg.key = &k2;
+  node2 = dll_insert(head, reg);
+  reg.key = &k3;
+  node3 = dll_insert(head, reg);
+  reg.key = &k4;
+  node4 = dll_insert(head, reg);
+  reg.key = &k5;
+  node5 = dll_insert(head, reg);
+  reg.key = &k6;
+  node6 = dll_insert(head, reg);
+  reg.key = &k7;
+  node7 = dll_insert(head, reg);
+  reg.key = &k8;
+  node8 = dll_insert(head, reg);
+  reg.key = &k9;
+  node9 = dll_insert(head, reg);
+  reg.key = &k10;
+  node10 = dll_insert(head, reg);
+
+  insertion_sort_dll(head, start, end, compare);
+
+  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
+  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 8);
+  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 9);
+
+  free(node10);
+  free(node9);
+  free(node8);
+  free(node7);
+  free(node6);
+  free(node5);
+  free(node4);
+  free(node3);
+  free(node2);
+  free(node1);
+  free(head);
+}
+END_TEST
+
 Suite *make_test_suite(void)
 {
   Suite *s;
@@ -4779,6 +5955,23 @@ Suite *make_test_suite(void)
   tcase_add_test(tc_core, test_insertion_sort_gnrc_14);
   tcase_add_test(tc_core, test_insertion_sort_gnrc_15);
   tcase_add_test(tc_core, test_insertion_sort_gnrc_16);
+
+  tcase_add_test(tc_core, test_insertion_sort_dll_1);
+  tcase_add_test(tc_core, test_insertion_sort_dll_2);
+  tcase_add_test(tc_core, test_insertion_sort_dll_3);
+  tcase_add_test(tc_core, test_insertion_sort_dll_4);
+  tcase_add_test(tc_core, test_insertion_sort_dll_5);
+  tcase_add_test(tc_core, test_insertion_sort_dll_6);
+  tcase_add_test(tc_core, test_insertion_sort_dll_7);
+  tcase_add_test(tc_core, test_insertion_sort_dll_8);
+  tcase_add_test(tc_core, test_insertion_sort_dll_9);
+  tcase_add_test(tc_core, test_insertion_sort_dll_10);
+  tcase_add_test(tc_core, test_insertion_sort_dll_11);
+  tcase_add_test(tc_core, test_insertion_sort_dll_12);
+  tcase_add_test(tc_core, test_insertion_sort_dll_13);
+  tcase_add_test(tc_core, test_insertion_sort_dll_14);
+  tcase_add_test(tc_core, test_insertion_sort_dll_15);
+  tcase_add_test(tc_core, test_insertion_sort_dll_16);
 
   suite_add_tcase(s, tc_core);
 

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -1,12 +1,12 @@
 #include <check.h>
 #include <malloc.h>
+#include <math.h>
 #include <sort.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <math.h>
 
-Suite *make_test_suite(void);
+Suite* make_test_suite(void);
 int compare_int(void* key1, void* key2);
 int compare_float(void* key1, void* key2);
 int compare_double(void* key1, void* key2);
@@ -18,8 +18,8 @@ int seed = 23;
 int compare_int(void* key1, void* key2)
 {
   int result;
-  int k1 = *((int *)key1);
-  int k2 = *((int *)key2);
+  int k1 = *((int*)key1);
+  int k2 = *((int*)key2);
 
   if (k1 > k2)
     {
@@ -39,8 +39,8 @@ int compare_int(void* key1, void* key2)
 int compare_float(void* key1, void* key2)
 {
   int result;
-  float k1 = *((float *)key1);
-  float k2 = *((float *)key2);
+  float k1 = *((float*)key1);
+  float k2 = *((float*)key2);
 
   if (k1 > k2)
     {
@@ -60,8 +60,8 @@ int compare_float(void* key1, void* key2)
 int compare_double(void* key1, void* key2)
 {
   int result;
-  double k1 = *((double *)key1);
-  double k2 = *((double *)key2);
+  double k1 = *((double*)key1);
+  double k2 = *((double*)key2);
 
   if (k1 > k2)
     {
@@ -81,9 +81,9 @@ int compare_double(void* key1, void* key2)
 int mul_plus_floor_float(int n, void* key)
 {
   int result;
-  float temp = *((float *)key);
+  float temp = *((float*)key);
   temp = floor(n * temp);
-  result = (int) temp;
+  result = (int)temp;
 
   return result;
 }
@@ -91,9 +91,9 @@ int mul_plus_floor_float(int n, void* key)
 int mul_plus_floor_double(int n, void* key)
 {
   int result;
-  double temp = *((double *)key);
+  double temp = *((double*)key);
   temp = floor(n * temp);
-  result = (int) temp;
+  result = (int)temp;
 
   return result;
 }
@@ -3132,7 +3132,7 @@ END_TEST
 
 START_TEST(test_counting_sort_1)
 {
-  int *out;
+  int* out;
   int length = 6;
   int upper_limit = 10;
   int array[] = {5, 2, 4, 6, 1, 3};
@@ -3154,7 +3154,7 @@ END_TEST
 
 START_TEST(test_counting_sort_2)
 {
-  int *out;
+  int* out;
   int length = 1;
   int upper_limit = 10;
   int array[] = {5};
@@ -3171,7 +3171,7 @@ END_TEST
 
 START_TEST(test_counting_sort_3)
 {
-  int *out;
+  int* out;
   int length = 11;
   int upper_limit = 250;
   int array[] = {10, 15, 5, 20, 50, 0, 100, 75, 30, 200, 2};
@@ -3198,7 +3198,7 @@ END_TEST
 
 START_TEST(test_counting_sort_4)
 {
-  int *out;
+  int* out;
   int length = 10;
   int upper_limit = 250;
   int array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -3224,7 +3224,7 @@ END_TEST
 
 START_TEST(test_counting_sort_5)
 {
-  int *out;
+  int* out;
   int length = 10;
   int upper_limit = 20;
   int array[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
@@ -3250,7 +3250,7 @@ END_TEST
 
 START_TEST(test_counting_sort_6)
 {
-  int *out;
+  int* out;
   int length = 6;
   int upper_limit = 20;
   int array[] = {2, 4, 5, 1, 2, 3, 7, 6};
@@ -3272,7 +3272,7 @@ END_TEST
 
 START_TEST(test_counting_sort_7)
 {
-  int *out;
+  int* out;
   int length = 14;
   int upper_limit = 1000;
   int array[] = {0, 4, 2, 55, 300, 3, 700, 200, 100, 80, 7, 30, 150, 570};
@@ -3302,7 +3302,7 @@ END_TEST
 
 START_TEST(test_counting_sort_8)
 {
-  int *out;
+  int* out;
   int length = 12;
   int upper_limit = 1000;
   int array[] = {3, 15, 20, 30, 50, 75, 750, 500, 300, 200, 150, 10};
@@ -3330,7 +3330,7 @@ END_TEST
 
 START_TEST(test_counting_sort_9)
 {
-  int *out;
+  int* out;
   int length = 6;
   int upper_limit = 10;
   int array[] = {5, 2, 4, 6, 1, 3};
@@ -3352,7 +3352,7 @@ END_TEST
 
 START_TEST(test_counting_sort_10)
 {
-  int *out;
+  int* out;
   int length = 11;
   int upper_limit = 200;
   int array[] = {10, 15, 5, 20, 50, 0, 100, 75, 30, 200, 122};
@@ -3379,7 +3379,7 @@ END_TEST
 
 START_TEST(test_counting_sort_11)
 {
-  int *out;
+  int* out;
   int length = 10;
   int upper_limit = 200;
   int array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -3405,7 +3405,7 @@ END_TEST
 
 START_TEST(test_counting_sort_12)
 {
-  int *out;
+  int* out;
   int length = 10;
   int upper_limit = 200;
   int array[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
@@ -3431,7 +3431,7 @@ END_TEST
 
 START_TEST(test_counting_sort_by_nth_digit_1)
 {
-  int *out;
+  int* out;
   int n = 1;
   int length = 9;
   int array[] = {81, 56, 47, 19, 24, 62, 93, 35, 8};
@@ -3456,7 +3456,7 @@ END_TEST
 
 START_TEST(test_counting_sort_by_nth_digit_2)
 {
-  int *out;
+  int* out;
   int n = 2;
   int length = 10;
   int array[] = {160, 122, 128, 79, 77, 13, 99, 8, 26, 108};
@@ -3482,7 +3482,7 @@ END_TEST
 
 START_TEST(test_counting_sort_by_nth_digit_3)
 {
-  int *out;
+  int* out;
   int n = 1;
   int length = 8;
   int array[] = {170, 45, 75, 90, 802, 24, 2, 66};
@@ -3506,7 +3506,7 @@ END_TEST
 
 START_TEST(test_counting_sort_by_nth_digit_4)
 {
-  int *out;
+  int* out;
   int n = 2;
   int length = 8;
   int array[] = {170, 90, 802, 2, 24, 45, 75, 66};
@@ -3530,7 +3530,7 @@ END_TEST
 
 START_TEST(test_counting_sort_by_nth_digit_5)
 {
-  int *out;
+  int* out;
   int n = 3;
   int length = 8;
   int array[] = {802, 2, 24, 45, 66, 170, 75, 90};
@@ -3554,7 +3554,7 @@ END_TEST
 
 START_TEST(test_counting_sort_by_nth_digit_6)
 {
-  int *out;
+  int* out;
   int n = 1;
   int length = 30;
   int array[] = {698, 506, 619, 179, 524, 714, 890, 41,  358, 656,
@@ -3602,7 +3602,7 @@ END_TEST
 
 START_TEST(test_radix_sort_1)
 {
-  int *out;
+  int* out;
   int length = 6;
   int max_decimal_place = 1;
   int array[] = {5, 2, 4, 6, 1, 3};
@@ -3624,7 +3624,7 @@ END_TEST
 
 START_TEST(test_radix_sort_2)
 {
-  int *out;
+  int* out;
   int length = 1;
   int max_decimal_place = 1;
   int array[] = {5};
@@ -3641,7 +3641,7 @@ END_TEST
 
 START_TEST(test_radix_sort_3)
 {
-  int *out;
+  int* out;
   int length = 11;
   int max_decimal_place = 3;
   int array[] = {10, 15, 5, 20, 50, 0, 100, 75, 30, 200, 2};
@@ -3668,7 +3668,7 @@ END_TEST
 
 START_TEST(test_radix_sort_4)
 {
-  int *out;
+  int* out;
   int length = 10;
   int max_decimal_place = 1;
   int array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -3694,7 +3694,7 @@ END_TEST
 
 START_TEST(test_radix_sort_5)
 {
-  int *out;
+  int* out;
   int length = 10;
   int max_decimal_place = 1;
   int array[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
@@ -3720,7 +3720,7 @@ END_TEST
 
 START_TEST(test_radix_sort_6)
 {
-  int *out;
+  int* out;
   int length = 6;
   int max_decimal_place = 1;
   int array[] = {2, 4, 5, 1, 2, 3, 7, 6};
@@ -3742,7 +3742,7 @@ END_TEST
 
 START_TEST(test_radix_sort_7)
 {
-  int *out;
+  int* out;
   int length = 14;
   int max_decimal_place = 3;
   int array[] = {0, 4, 2, 55, 300, 3, 700, 200, 100, 80, 7, 30, 150, 570};
@@ -3772,7 +3772,7 @@ END_TEST
 
 START_TEST(test_radix_sort_8)
 {
-  int *out;
+  int* out;
   int length = 12;
   int max_decimal_place = 3;
   int array[] = {3, 15, 20, 30, 50, 75, 750, 500, 300, 200, 150, 10};
@@ -3800,7 +3800,7 @@ END_TEST
 
 START_TEST(test_radix_sort_9)
 {
-  int *out;
+  int* out;
   int length = 6;
   int max_decimal_place = 1;
   int array[] = {5, 2, 4, 6, 1, 3};
@@ -3822,7 +3822,7 @@ END_TEST
 
 START_TEST(test_radix_sort_10)
 {
-  int *out;
+  int* out;
   int length = 11;
   int max_decimal_place = 3;
   int array[] = {10, 15, 5, 20, 50, 0, 100, 75, 30, 200, 122};
@@ -3849,7 +3849,7 @@ END_TEST
 
 START_TEST(test_radix_sort_11)
 {
-  int *out;
+  int* out;
   int length = 10;
   int max_decimal_place = 1;
   int array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -3875,7 +3875,7 @@ END_TEST
 
 START_TEST(test_radix_sort_12)
 {
-  int *out;
+  int* out;
   int length = 10;
   int max_decimal_place = 1;
   int array[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
@@ -3901,7 +3901,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_1)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6;
   int length = 6;
   int start = 0;
@@ -3925,12 +3925,12 @@ START_TEST(test_insertion_sort_gnrc_1)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 1);
-  ck_assert_int_eq(*((int *)array[1].key), 2);
-  ck_assert_int_eq(*((int *)array[2].key), 3);
-  ck_assert_int_eq(*((int *)array[3].key), 4);
-  ck_assert_int_eq(*((int *)array[4].key), 5);
-  ck_assert_int_eq(*((int *)array[5].key), 6);
+  ck_assert_int_eq(*((int*)array[0].key), 1);
+  ck_assert_int_eq(*((int*)array[1].key), 2);
+  ck_assert_int_eq(*((int*)array[2].key), 3);
+  ck_assert_int_eq(*((int*)array[3].key), 4);
+  ck_assert_int_eq(*((int*)array[4].key), 5);
+  ck_assert_int_eq(*((int*)array[5].key), 6);
 
   free(array);
 }
@@ -3938,7 +3938,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_2)
 {
-  Register *array;
+  Register* array;
   int k1 = 5;
   int length = 1;
   int start = 0;
@@ -3950,7 +3950,7 @@ START_TEST(test_insertion_sort_gnrc_2)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 5);
+  ck_assert_int_eq(*((int*)array[0].key), 5);
 
   free(array);
 }
@@ -3958,7 +3958,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_3)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11;
   int length = 11;
   int start = 0;
@@ -3992,17 +3992,17 @@ START_TEST(test_insertion_sort_gnrc_3)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), -200);
-  ck_assert_int_eq(*((int *)array[1].key), -20);
-  ck_assert_int_eq(*((int *)array[2].key), -10);
-  ck_assert_int_eq(*((int *)array[3].key), -5);
-  ck_assert_int_eq(*((int *)array[4].key), 0);
-  ck_assert_int_eq(*((int *)array[5].key), 15);
-  ck_assert_int_eq(*((int *)array[6].key), 30);
-  ck_assert_int_eq(*((int *)array[7].key), 50);
-  ck_assert_int_eq(*((int *)array[8].key), 75);
-  ck_assert_int_eq(*((int *)array[9].key), 100);
-  ck_assert_int_eq(*((int *)array[10].key), 200);
+  ck_assert_int_eq(*((int*)array[0].key), -200);
+  ck_assert_int_eq(*((int*)array[1].key), -20);
+  ck_assert_int_eq(*((int*)array[2].key), -10);
+  ck_assert_int_eq(*((int*)array[3].key), -5);
+  ck_assert_int_eq(*((int*)array[4].key), 0);
+  ck_assert_int_eq(*((int*)array[5].key), 15);
+  ck_assert_int_eq(*((int*)array[6].key), 30);
+  ck_assert_int_eq(*((int*)array[7].key), 50);
+  ck_assert_int_eq(*((int*)array[8].key), 75);
+  ck_assert_int_eq(*((int*)array[9].key), 100);
+  ck_assert_int_eq(*((int*)array[10].key), 200);
 
   free(array);
 }
@@ -4010,7 +4010,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_4)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
   int length = 10;
   int start = 0;
@@ -4042,16 +4042,16 @@ START_TEST(test_insertion_sort_gnrc_4)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 0);
-  ck_assert_int_eq(*((int *)array[1].key), 1);
-  ck_assert_int_eq(*((int *)array[2].key), 2);
-  ck_assert_int_eq(*((int *)array[3].key), 3);
-  ck_assert_int_eq(*((int *)array[4].key), 4);
-  ck_assert_int_eq(*((int *)array[5].key), 5);
-  ck_assert_int_eq(*((int *)array[6].key), 6);
-  ck_assert_int_eq(*((int *)array[7].key), 7);
-  ck_assert_int_eq(*((int *)array[8].key), 8);
-  ck_assert_int_eq(*((int *)array[9].key), 9);
+  ck_assert_int_eq(*((int*)array[0].key), 0);
+  ck_assert_int_eq(*((int*)array[1].key), 1);
+  ck_assert_int_eq(*((int*)array[2].key), 2);
+  ck_assert_int_eq(*((int*)array[3].key), 3);
+  ck_assert_int_eq(*((int*)array[4].key), 4);
+  ck_assert_int_eq(*((int*)array[5].key), 5);
+  ck_assert_int_eq(*((int*)array[6].key), 6);
+  ck_assert_int_eq(*((int*)array[7].key), 7);
+  ck_assert_int_eq(*((int*)array[8].key), 8);
+  ck_assert_int_eq(*((int*)array[9].key), 9);
 
   free(array);
 }
@@ -4059,7 +4059,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_5)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
   int length = 10;
   int start = 0;
@@ -4091,16 +4091,16 @@ START_TEST(test_insertion_sort_gnrc_5)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 0);
-  ck_assert_int_eq(*((int *)array[1].key), 1);
-  ck_assert_int_eq(*((int *)array[2].key), 2);
-  ck_assert_int_eq(*((int *)array[3].key), 3);
-  ck_assert_int_eq(*((int *)array[4].key), 4);
-  ck_assert_int_eq(*((int *)array[5].key), 5);
-  ck_assert_int_eq(*((int *)array[6].key), 6);
-  ck_assert_int_eq(*((int *)array[7].key), 7);
-  ck_assert_int_eq(*((int *)array[8].key), 8);
-  ck_assert_int_eq(*((int *)array[9].key), 9);
+  ck_assert_int_eq(*((int*)array[0].key), 0);
+  ck_assert_int_eq(*((int*)array[1].key), 1);
+  ck_assert_int_eq(*((int*)array[2].key), 2);
+  ck_assert_int_eq(*((int*)array[3].key), 3);
+  ck_assert_int_eq(*((int*)array[4].key), 4);
+  ck_assert_int_eq(*((int*)array[5].key), 5);
+  ck_assert_int_eq(*((int*)array[6].key), 6);
+  ck_assert_int_eq(*((int*)array[7].key), 7);
+  ck_assert_int_eq(*((int*)array[8].key), 8);
+  ck_assert_int_eq(*((int*)array[9].key), 9);
 
   free(array);
 }
@@ -4108,7 +4108,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_6)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8;
   int length = 8;
   int start = 2;
@@ -4136,14 +4136,14 @@ START_TEST(test_insertion_sort_gnrc_6)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 2);
-  ck_assert_int_eq(*((int *)array[1].key), 4);
-  ck_assert_int_eq(*((int *)array[2].key), 1);
-  ck_assert_int_eq(*((int *)array[3].key), 2);
-  ck_assert_int_eq(*((int *)array[4].key), 3);
-  ck_assert_int_eq(*((int *)array[5].key), 5);
-  ck_assert_int_eq(*((int *)array[6].key), 6);
-  ck_assert_int_eq(*((int *)array[7].key), 7);
+  ck_assert_int_eq(*((int*)array[0].key), 2);
+  ck_assert_int_eq(*((int*)array[1].key), 4);
+  ck_assert_int_eq(*((int*)array[2].key), 1);
+  ck_assert_int_eq(*((int*)array[3].key), 2);
+  ck_assert_int_eq(*((int*)array[4].key), 3);
+  ck_assert_int_eq(*((int*)array[5].key), 5);
+  ck_assert_int_eq(*((int*)array[6].key), 6);
+  ck_assert_int_eq(*((int*)array[7].key), 7);
 
   free(array);
 }
@@ -4151,7 +4151,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_7)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8;
   int length = 8;
   int start = 0;
@@ -4179,14 +4179,14 @@ START_TEST(test_insertion_sort_gnrc_7)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 1);
-  ck_assert_int_eq(*((int *)array[1].key), 2);
-  ck_assert_int_eq(*((int *)array[2].key), 2);
-  ck_assert_int_eq(*((int *)array[3].key), 3);
-  ck_assert_int_eq(*((int *)array[4].key), 4);
-  ck_assert_int_eq(*((int *)array[5].key), 5);
-  ck_assert_int_eq(*((int *)array[6].key), 7);
-  ck_assert_int_eq(*((int *)array[7].key), 6);
+  ck_assert_int_eq(*((int*)array[0].key), 1);
+  ck_assert_int_eq(*((int*)array[1].key), 2);
+  ck_assert_int_eq(*((int*)array[2].key), 2);
+  ck_assert_int_eq(*((int*)array[3].key), 3);
+  ck_assert_int_eq(*((int*)array[4].key), 4);
+  ck_assert_int_eq(*((int*)array[5].key), 5);
+  ck_assert_int_eq(*((int*)array[6].key), 7);
+  ck_assert_int_eq(*((int*)array[7].key), 6);
 
   free(array);
 }
@@ -4194,7 +4194,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_8)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8;
   int length = 8;
   int start = 2;
@@ -4222,14 +4222,14 @@ START_TEST(test_insertion_sort_gnrc_8)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 2);
-  ck_assert_int_eq(*((int *)array[1].key), 4);
-  ck_assert_int_eq(*((int *)array[2].key), 1);
-  ck_assert_int_eq(*((int *)array[3].key), 2);
-  ck_assert_int_eq(*((int *)array[4].key), 3);
-  ck_assert_int_eq(*((int *)array[5].key), 5);
-  ck_assert_int_eq(*((int *)array[6].key), 7);
-  ck_assert_int_eq(*((int *)array[7].key), 6);
+  ck_assert_int_eq(*((int*)array[0].key), 2);
+  ck_assert_int_eq(*((int*)array[1].key), 4);
+  ck_assert_int_eq(*((int*)array[2].key), 1);
+  ck_assert_int_eq(*((int*)array[3].key), 2);
+  ck_assert_int_eq(*((int*)array[4].key), 3);
+  ck_assert_int_eq(*((int*)array[5].key), 5);
+  ck_assert_int_eq(*((int*)array[6].key), 7);
+  ck_assert_int_eq(*((int*)array[7].key), 6);
 
   free(array);
 }
@@ -4237,7 +4237,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_9)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14;
   int length = 14;
   int start = 0;
@@ -4277,20 +4277,20 @@ START_TEST(test_insertion_sort_gnrc_9)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), -200);
-  ck_assert_int_eq(*((int *)array[1].key), -100);
-  ck_assert_int_eq(*((int *)array[2].key), -80);
-  ck_assert_int_eq(*((int *)array[3].key), -7);
-  ck_assert_int_eq(*((int *)array[4].key), 0);
-  ck_assert_int_eq(*((int *)array[5].key), 2);
-  ck_assert_int_eq(*((int *)array[6].key), 3);
-  ck_assert_int_eq(*((int *)array[7].key), 4);
-  ck_assert_int_eq(*((int *)array[8].key), 30);
-  ck_assert_int_eq(*((int *)array[9].key), 55);
-  ck_assert_int_eq(*((int *)array[10].key), 150);
-  ck_assert_int_eq(*((int *)array[11].key), 300);
-  ck_assert_int_eq(*((int *)array[12].key), 570);
-  ck_assert_int_eq(*((int *)array[13].key), 700);
+  ck_assert_int_eq(*((int*)array[0].key), -200);
+  ck_assert_int_eq(*((int*)array[1].key), -100);
+  ck_assert_int_eq(*((int*)array[2].key), -80);
+  ck_assert_int_eq(*((int*)array[3].key), -7);
+  ck_assert_int_eq(*((int*)array[4].key), 0);
+  ck_assert_int_eq(*((int*)array[5].key), 2);
+  ck_assert_int_eq(*((int*)array[6].key), 3);
+  ck_assert_int_eq(*((int*)array[7].key), 4);
+  ck_assert_int_eq(*((int*)array[8].key), 30);
+  ck_assert_int_eq(*((int*)array[9].key), 55);
+  ck_assert_int_eq(*((int*)array[10].key), 150);
+  ck_assert_int_eq(*((int*)array[11].key), 300);
+  ck_assert_int_eq(*((int*)array[12].key), 570);
+  ck_assert_int_eq(*((int*)array[13].key), 700);
 
   free(array);
 }
@@ -4298,7 +4298,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_10)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14;
   int length = 14;
   int start = 2;
@@ -4338,20 +4338,20 @@ START_TEST(test_insertion_sort_gnrc_10)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 0);
-  ck_assert_int_eq(*((int *)array[1].key), 2);
-  ck_assert_int_eq(*((int *)array[2].key), -200);
-  ck_assert_int_eq(*((int *)array[3].key), -100);
-  ck_assert_int_eq(*((int *)array[4].key), -80);
-  ck_assert_int_eq(*((int *)array[5].key), -7);
-  ck_assert_int_eq(*((int *)array[6].key), 3);
-  ck_assert_int_eq(*((int *)array[7].key), 4);
-  ck_assert_int_eq(*((int *)array[8].key), 30);
-  ck_assert_int_eq(*((int *)array[9].key), 55);
-  ck_assert_int_eq(*((int *)array[10].key), 300);
-  ck_assert_int_eq(*((int *)array[11].key), 700);
-  ck_assert_int_eq(*((int *)array[12].key), 150);
-  ck_assert_int_eq(*((int *)array[13].key), 570);
+  ck_assert_int_eq(*((int*)array[0].key), 0);
+  ck_assert_int_eq(*((int*)array[1].key), 2);
+  ck_assert_int_eq(*((int*)array[2].key), -200);
+  ck_assert_int_eq(*((int*)array[3].key), -100);
+  ck_assert_int_eq(*((int*)array[4].key), -80);
+  ck_assert_int_eq(*((int*)array[5].key), -7);
+  ck_assert_int_eq(*((int*)array[6].key), 3);
+  ck_assert_int_eq(*((int*)array[7].key), 4);
+  ck_assert_int_eq(*((int*)array[8].key), 30);
+  ck_assert_int_eq(*((int*)array[9].key), 55);
+  ck_assert_int_eq(*((int*)array[10].key), 300);
+  ck_assert_int_eq(*((int*)array[11].key), 700);
+  ck_assert_int_eq(*((int*)array[12].key), 150);
+  ck_assert_int_eq(*((int*)array[13].key), 570);
 
   free(array);
 }
@@ -4359,7 +4359,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_11)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12;
   int length = 12;
   int start = 0;
@@ -4395,18 +4395,18 @@ START_TEST(test_insertion_sort_gnrc_11)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), -75);
-  ck_assert_int_eq(*((int *)array[1].key), -50);
-  ck_assert_int_eq(*((int *)array[2].key), -30);
-  ck_assert_int_eq(*((int *)array[3].key), -20);
-  ck_assert_int_eq(*((int *)array[4].key), -15);
-  ck_assert_int_eq(*((int *)array[5].key), -3);
-  ck_assert_int_eq(*((int *)array[6].key), 3);
-  ck_assert_int_eq(*((int *)array[7].key), 15);
-  ck_assert_int_eq(*((int *)array[8].key), 20);
-  ck_assert_int_eq(*((int *)array[9].key), 30);
-  ck_assert_int_eq(*((int *)array[10].key), 50);
-  ck_assert_int_eq(*((int *)array[11].key), 75);
+  ck_assert_int_eq(*((int*)array[0].key), -75);
+  ck_assert_int_eq(*((int*)array[1].key), -50);
+  ck_assert_int_eq(*((int*)array[2].key), -30);
+  ck_assert_int_eq(*((int*)array[3].key), -20);
+  ck_assert_int_eq(*((int*)array[4].key), -15);
+  ck_assert_int_eq(*((int*)array[5].key), -3);
+  ck_assert_int_eq(*((int*)array[6].key), 3);
+  ck_assert_int_eq(*((int*)array[7].key), 15);
+  ck_assert_int_eq(*((int*)array[8].key), 20);
+  ck_assert_int_eq(*((int*)array[9].key), 30);
+  ck_assert_int_eq(*((int*)array[10].key), 50);
+  ck_assert_int_eq(*((int*)array[11].key), 75);
 
   free(array);
 }
@@ -4414,7 +4414,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_12)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6;
   int length = 6;
   int start = 0;
@@ -4438,12 +4438,12 @@ START_TEST(test_insertion_sort_gnrc_12)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 1);
-  ck_assert_int_eq(*((int *)array[1].key), 2);
-  ck_assert_int_eq(*((int *)array[2].key), 3);
-  ck_assert_int_eq(*((int *)array[3].key), 4);
-  ck_assert_int_eq(*((int *)array[4].key), 5);
-  ck_assert_int_eq(*((int *)array[5].key), 6);
+  ck_assert_int_eq(*((int*)array[0].key), 1);
+  ck_assert_int_eq(*((int*)array[1].key), 2);
+  ck_assert_int_eq(*((int*)array[2].key), 3);
+  ck_assert_int_eq(*((int*)array[3].key), 4);
+  ck_assert_int_eq(*((int*)array[4].key), 5);
+  ck_assert_int_eq(*((int*)array[5].key), 6);
 
   free(array);
 }
@@ -4451,7 +4451,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_13)
 {
-  Register *array;
+  Register* array;
   int k1;
   int length = 1;
   int start = 0;
@@ -4465,7 +4465,7 @@ START_TEST(test_insertion_sort_gnrc_13)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 5);
+  ck_assert_int_eq(*((int*)array[0].key), 5);
 
   free(array);
 }
@@ -4473,7 +4473,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_14)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11;
   int length = 11;
   int start = 0;
@@ -4507,17 +4507,17 @@ START_TEST(test_insertion_sort_gnrc_14)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), -200);
-  ck_assert_int_eq(*((int *)array[1].key), -20);
-  ck_assert_int_eq(*((int *)array[2].key), -10);
-  ck_assert_int_eq(*((int *)array[3].key), -5);
-  ck_assert_int_eq(*((int *)array[4].key), 0);
-  ck_assert_int_eq(*((int *)array[5].key), 15);
-  ck_assert_int_eq(*((int *)array[6].key), 30);
-  ck_assert_int_eq(*((int *)array[7].key), 50);
-  ck_assert_int_eq(*((int *)array[8].key), 75);
-  ck_assert_int_eq(*((int *)array[9].key), 100);
-  ck_assert_int_eq(*((int *)array[10].key), 200);
+  ck_assert_int_eq(*((int*)array[0].key), -200);
+  ck_assert_int_eq(*((int*)array[1].key), -20);
+  ck_assert_int_eq(*((int*)array[2].key), -10);
+  ck_assert_int_eq(*((int*)array[3].key), -5);
+  ck_assert_int_eq(*((int*)array[4].key), 0);
+  ck_assert_int_eq(*((int*)array[5].key), 15);
+  ck_assert_int_eq(*((int*)array[6].key), 30);
+  ck_assert_int_eq(*((int*)array[7].key), 50);
+  ck_assert_int_eq(*((int*)array[8].key), 75);
+  ck_assert_int_eq(*((int*)array[9].key), 100);
+  ck_assert_int_eq(*((int*)array[10].key), 200);
 
   free(array);
 }
@@ -4525,7 +4525,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_15)
 {
-  Register *array;
+  Register* array;
   int length = 10;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
   int start = 0;
@@ -4557,16 +4557,16 @@ START_TEST(test_insertion_sort_gnrc_15)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 0);
-  ck_assert_int_eq(*((int *)array[1].key), 1);
-  ck_assert_int_eq(*((int *)array[2].key), 2);
-  ck_assert_int_eq(*((int *)array[3].key), 3);
-  ck_assert_int_eq(*((int *)array[4].key), 4);
-  ck_assert_int_eq(*((int *)array[5].key), 5);
-  ck_assert_int_eq(*((int *)array[6].key), 6);
-  ck_assert_int_eq(*((int *)array[7].key), 7);
-  ck_assert_int_eq(*((int *)array[8].key), 8);
-  ck_assert_int_eq(*((int *)array[9].key), 9);
+  ck_assert_int_eq(*((int*)array[0].key), 0);
+  ck_assert_int_eq(*((int*)array[1].key), 1);
+  ck_assert_int_eq(*((int*)array[2].key), 2);
+  ck_assert_int_eq(*((int*)array[3].key), 3);
+  ck_assert_int_eq(*((int*)array[4].key), 4);
+  ck_assert_int_eq(*((int*)array[5].key), 5);
+  ck_assert_int_eq(*((int*)array[6].key), 6);
+  ck_assert_int_eq(*((int*)array[7].key), 7);
+  ck_assert_int_eq(*((int*)array[8].key), 8);
+  ck_assert_int_eq(*((int*)array[9].key), 9);
 
   free(array);
 }
@@ -4574,7 +4574,7 @@ END_TEST
 
 START_TEST(test_insertion_sort_gnrc_16)
 {
-  Register *array;
+  Register* array;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
   int length = 10;
   int start = 0;
@@ -4606,16 +4606,16 @@ START_TEST(test_insertion_sort_gnrc_16)
 
   insertion_sort_gnrc(array, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)array[0].key), 0);
-  ck_assert_int_eq(*((int *)array[1].key), 1);
-  ck_assert_int_eq(*((int *)array[2].key), 2);
-  ck_assert_int_eq(*((int *)array[3].key), 3);
-  ck_assert_int_eq(*((int *)array[4].key), 4);
-  ck_assert_int_eq(*((int *)array[5].key), 5);
-  ck_assert_int_eq(*((int *)array[6].key), 6);
-  ck_assert_int_eq(*((int *)array[7].key), 7);
-  ck_assert_int_eq(*((int *)array[8].key), 8);
-  ck_assert_int_eq(*((int *)array[9].key), 9);
+  ck_assert_int_eq(*((int*)array[0].key), 0);
+  ck_assert_int_eq(*((int*)array[1].key), 1);
+  ck_assert_int_eq(*((int*)array[2].key), 2);
+  ck_assert_int_eq(*((int*)array[3].key), 3);
+  ck_assert_int_eq(*((int*)array[4].key), 4);
+  ck_assert_int_eq(*((int*)array[5].key), 5);
+  ck_assert_int_eq(*((int*)array[6].key), 6);
+  ck_assert_int_eq(*((int*)array[7].key), 7);
+  ck_assert_int_eq(*((int*)array[8].key), 8);
+  ck_assert_int_eq(*((int*)array[9].key), 9);
 
   free(array);
 }
@@ -4661,13 +4661,13 @@ START_TEST(test_insertion_sort_dll_1)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 1);
-  
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 6); 
+  ck_assert_int_eq(*((int*)(*head)->data.key), 1);
+
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 3);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 6);
 
   free(node1);
   free(node2);
@@ -4697,8 +4697,8 @@ START_TEST(test_insertion_sort_dll_2)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 5);
-  ck_assert_int_eq(*((int *)node1->data.key), 5);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 5);
+  ck_assert_int_eq(*((int*)node1->data.key), 5);
 
   free(node1);
   free(head);
@@ -4765,17 +4765,29 @@ START_TEST(test_insertion_sort_dll_3)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), -200);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), -20);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -10);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 0);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 15);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 30);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 50);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 75);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 100);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 200);
+  ck_assert_int_eq(*((int*)(*head)->data.key), -200);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -20);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), -10);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), -5);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 0);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key),
+                   15);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 30);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 50);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->data.key),
+      75);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->next->data.key),
+      100);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->data.key),
+                   200);
 
   free(node11);
   free(node10);
@@ -4806,7 +4818,7 @@ START_TEST(test_insertion_sort_dll_4)
   DoublyLinkedList* node8;
   DoublyLinkedList* node9;
   DoublyLinkedList* node10;
-  
+
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
   int start = 0;
   int end = 9;
@@ -4848,17 +4860,24 @@ START_TEST(test_insertion_sort_dll_4)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-
-  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 8);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 9);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 1);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->data.key),
+      8);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->next->data.key),
+      9);
 
   free(node10);
   free(node9);
@@ -4887,9 +4906,9 @@ START_TEST(test_insertion_sort_dll_5)
   DoublyLinkedList* node7;
   DoublyLinkedList* node8;
   DoublyLinkedList* node9;
-  DoublyLinkedList* node10; 
+  DoublyLinkedList* node10;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
-  
+
   int start = 0;
   int end = 9;
 
@@ -4930,16 +4949,24 @@ START_TEST(test_insertion_sort_dll_5)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 8);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 9);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 1);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->data.key),
+      8);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->next->data.key),
+      9);
 
   free(node10);
   free(node9);
@@ -4968,7 +4995,7 @@ START_TEST(test_insertion_sort_dll_6)
   DoublyLinkedList* node7;
   DoublyLinkedList* node8;
   int k1, k2, k3, k4, k5, k6, k7, k8;
-  
+
   int start = 2;
   int end = 7;
 
@@ -5003,14 +5030,16 @@ START_TEST(test_insertion_sort_dll_6)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 1);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 4);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 1);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 7);
 
   free(node8);
   free(node7);
@@ -5037,7 +5066,7 @@ START_TEST(test_insertion_sort_dll_7)
   DoublyLinkedList* node7;
   DoublyLinkedList* node8;
   int k1, k2, k3, k4, k5, k6, k7, k8;
-  
+
   int start = 0;
   int end = 5;
 
@@ -5072,14 +5101,16 @@ START_TEST(test_insertion_sort_dll_7)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 1);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 7);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 1);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 6);
 
   free(node8);
   free(node7);
@@ -5106,7 +5137,7 @@ START_TEST(test_insertion_sort_dll_8)
   DoublyLinkedList* node7;
   DoublyLinkedList* node8;
   int k1, k2, k3, k4, k5, k6, k7, k8;
-  
+
   int start = 2;
   int end = 5;
 
@@ -5141,14 +5172,16 @@ START_TEST(test_insertion_sort_dll_8)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 1);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 7);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 4);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 1);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 6);
 
   free(node8);
   free(node7);
@@ -5234,20 +5267,40 @@ START_TEST(test_insertion_sort_dll_9)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), -200);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), -100);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -80);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -7);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 0);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 30);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 55);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 150);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->data.key), 300);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->next->data.key), 570);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->next->next->data.key), 700);
+  ck_assert_int_eq(*((int*)(*head)->data.key), -200);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -100);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), -80);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), -7);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 0);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 2);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->data.key),
+      30);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->next->data.key),
+      55);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->data.key),
+                   150);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->next->data.key),
+                   300);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->next->next->data.key),
+                   570);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->next->next->next->data.key),
+                   700);
 
   free(node14);
   free(node13);
@@ -5339,20 +5392,41 @@ START_TEST(test_insertion_sort_dll_10)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -200);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -100);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), -80);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), -7);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 30);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 55);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 300);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->data.key), 700);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->next->data.key), 150);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->next->next->data.key), 570);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), -200);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), -100);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), -80);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key),
+                   -7);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->data.key),
+      30);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->next->data.key),
+      55);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->data.key),
+                   300);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->next->data.key),
+                   700);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->next->next->data.key),
+                   150);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->next->next->next->data.key),
+                   570);
 
   free(node14);
   free(node13);
@@ -5436,19 +5510,34 @@ START_TEST(test_insertion_sort_dll_11)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), -75);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), -50);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -30);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -20);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), -15);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), -3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 15);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 20);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 30);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 50);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->next->data.key), 75);
-  
+  ck_assert_int_eq(*((int*)(*head)->data.key), -75);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -50);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), -30);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), -20);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), -15);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key),
+                   -3);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 3);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 15);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->data.key),
+      20);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->next->data.key),
+      30);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->data.key),
+                   50);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->next->data.key),
+                   75);
+
   free(node12);
   free(node11);
   free(node10);
@@ -5505,13 +5594,13 @@ START_TEST(test_insertion_sort_dll_12)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 1);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 6);
-  
+  ck_assert_int_eq(*((int*)(*head)->data.key), 1);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 3);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 6);
+
   free(node6);
   free(node5);
   free(node4);
@@ -5541,7 +5630,7 @@ START_TEST(test_insertion_sort_dll_13)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 5);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 5);
 
   free(node1);
   free(head);
@@ -5608,17 +5697,29 @@ START_TEST(test_insertion_sort_dll_14)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), -200);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), -20);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), -10);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), -5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 0);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 15);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 30);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 50);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 75);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 100);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->next->data.key), 200);
+  ck_assert_int_eq(*((int*)(*head)->data.key), -200);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), -20);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), -10);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), -5);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 0);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key),
+                   15);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 30);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 50);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->data.key),
+      75);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->next->data.key),
+      100);
+  ck_assert_int_eq(*((int*)(*head)
+                         ->next->next->next->next->next->next->next->next->next
+                         ->next->data.key),
+                   200);
 
   free(node11);
   free(node10);
@@ -5648,7 +5749,7 @@ START_TEST(test_insertion_sort_dll_15)
   DoublyLinkedList* node7;
   DoublyLinkedList* node8;
   DoublyLinkedList* node9;
-  DoublyLinkedList* node10; 
+  DoublyLinkedList* node10;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
 
   int start = 0;
@@ -5691,16 +5792,24 @@ START_TEST(test_insertion_sort_dll_15)
 
   insertion_sort_dll(head, start, end, compare_int);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 8);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 9);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 1);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->data.key),
+      8);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->next->data.key),
+      9);
 
   free(node10);
   free(node9);
@@ -5729,7 +5838,7 @@ START_TEST(test_insertion_sort_dll_16)
   DoublyLinkedList* node7;
   DoublyLinkedList* node8;
   DoublyLinkedList* node9;
-  DoublyLinkedList* node10; 
+  DoublyLinkedList* node10;
   int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
 
   int start = 0;
@@ -5772,16 +5881,24 @@ START_TEST(test_insertion_sort_dll_16)
 
   insertion_sort_dll(head, start, end, compare_float);
 
-  ck_assert_int_eq(*((int *)(*head)->data.key), 0);
-  ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
-  ck_assert_int_eq(*((int *)(*head)->next->next->data.key), 2);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->data.key), 3);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->data.key), 4);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->data.key), 5);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->data.key), 6);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->data.key), 7);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->data.key), 8);
-  ck_assert_int_eq(*((int *)(*head)->next->next->next->next->next->next->next->next->next->data.key), 9);
+  ck_assert_int_eq(*((int*)(*head)->data.key), 0);
+  ck_assert_int_eq(*((int*)(*head)->next->data.key), 1);
+  ck_assert_int_eq(*((int*)(*head)->next->next->data.key), 2);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->data.key), 3);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->data.key), 4);
+  ck_assert_int_eq(*((int*)(*head)->next->next->next->next->next->data.key), 5);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->data.key), 6);
+  ck_assert_int_eq(
+      *((int*)(*head)->next->next->next->next->next->next->next->data.key), 7);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->data.key),
+      8);
+  ck_assert_int_eq(
+      *((int*)(*head)
+            ->next->next->next->next->next->next->next->next->next->data.key),
+      9);
 
   free(node10);
   free(node9);
@@ -5821,12 +5938,12 @@ START_TEST(test_bucket_sort_1)
 
   bucket_sort(array, length, mul_plus_floor_float, compare_float);
 
-  ck_assert_float_eq(*((float *)array[0].key), 0.1);
-  ck_assert_float_eq(*((float *)array[1].key), 0.2);
-  ck_assert_float_eq(*((float *)array[2].key), 0.3);
-  ck_assert_float_eq(*((float *)array[3].key), 0.4);
-  ck_assert_float_eq(*((float *)array[4].key), 0.5);
-  ck_assert_float_eq(*((float *)array[5].key), 0.6);
+  ck_assert_float_eq(*((float*)array[0].key), 0.1);
+  ck_assert_float_eq(*((float*)array[1].key), 0.2);
+  ck_assert_float_eq(*((float*)array[2].key), 0.3);
+  ck_assert_float_eq(*((float*)array[3].key), 0.4);
+  ck_assert_float_eq(*((float*)array[4].key), 0.5);
+  ck_assert_float_eq(*((float*)array[5].key), 0.6);
 
   free(array);
 }
@@ -5839,14 +5956,14 @@ START_TEST(test_bucket_sort_2)
   int length = 1;
 
   k1 = 0.5;
-  
+
   array = malloc(length * sizeof(Register));
-  
+
   array[0].key = &k1;
-  
+
   bucket_sort(array, length, mul_plus_floor_float, compare_float);
 
-  ck_assert_float_eq(*((float *)array[0].key), 0.5);
+  ck_assert_float_eq(*((float*)array[0].key), 0.5);
 
   free(array);
 }
@@ -5871,7 +5988,7 @@ START_TEST(test_bucket_sort_3)
   k11 = 0.002;
 
   array = malloc(length * sizeof(Register));
-  
+
   array[0].key = &k1;
   array[1].key = &k2;
   array[2].key = &k3;
@@ -5886,17 +6003,17 @@ START_TEST(test_bucket_sort_3)
 
   bucket_sort(array, length, mul_plus_floor_float, compare_float);
 
-  ck_assert_float_eq(*((float *)array[0].key), 0);
-  ck_assert_float_eq(*((float *)array[1].key), 0.002);
-  ck_assert_float_eq(*((float *)array[2].key), 0.005);
-  ck_assert_float_eq(*((float *)array[3].key), 0.01);
-  ck_assert_float_eq(*((float *)array[4].key), 0.015);
-  ck_assert_float_eq(*((float *)array[5].key), 0.02);
-  ck_assert_float_eq(*((float *)array[6].key), 0.03);
-  ck_assert_float_eq(*((float *)array[7].key), 0.05);
-  ck_assert_float_eq(*((float *)array[8].key), 0.075);
-  ck_assert_float_eq(*((float *)array[9].key), 0.1);
-  ck_assert_float_eq(*((float *)array[10].key), 0.2);
+  ck_assert_float_eq(*((float*)array[0].key), 0);
+  ck_assert_float_eq(*((float*)array[1].key), 0.002);
+  ck_assert_float_eq(*((float*)array[2].key), 0.005);
+  ck_assert_float_eq(*((float*)array[3].key), 0.01);
+  ck_assert_float_eq(*((float*)array[4].key), 0.015);
+  ck_assert_float_eq(*((float*)array[5].key), 0.02);
+  ck_assert_float_eq(*((float*)array[6].key), 0.03);
+  ck_assert_float_eq(*((float*)array[7].key), 0.05);
+  ck_assert_float_eq(*((float*)array[8].key), 0.075);
+  ck_assert_float_eq(*((float*)array[9].key), 0.1);
+  ck_assert_float_eq(*((float*)array[10].key), 0.2);
 
   free(array);
 }
@@ -5934,16 +6051,16 @@ START_TEST(test_bucket_sort_4)
 
   bucket_sort(array, length, mul_plus_floor_float, compare_float);
 
-  ck_assert_float_eq(*((float *)array[0].key), 0);
-  ck_assert_float_eq(*((float *)array[1].key), 0.1);
-  ck_assert_float_eq(*((float *)array[2].key), 0.2);
-  ck_assert_float_eq(*((float *)array[3].key), 0.3);
-  ck_assert_float_eq(*((float *)array[4].key), 0.4);
-  ck_assert_float_eq(*((float *)array[5].key), 0.5);
-  ck_assert_float_eq(*((float *)array[6].key), 0.6);
-  ck_assert_float_eq(*((float *)array[7].key), 0.7);
-  ck_assert_float_eq(*((float *)array[8].key), 0.8);
-  ck_assert_float_eq(*((float *)array[9].key), 0.9);
+  ck_assert_float_eq(*((float*)array[0].key), 0);
+  ck_assert_float_eq(*((float*)array[1].key), 0.1);
+  ck_assert_float_eq(*((float*)array[2].key), 0.2);
+  ck_assert_float_eq(*((float*)array[3].key), 0.3);
+  ck_assert_float_eq(*((float*)array[4].key), 0.4);
+  ck_assert_float_eq(*((float*)array[5].key), 0.5);
+  ck_assert_float_eq(*((float*)array[6].key), 0.6);
+  ck_assert_float_eq(*((float*)array[7].key), 0.7);
+  ck_assert_float_eq(*((float*)array[8].key), 0.8);
+  ck_assert_float_eq(*((float*)array[9].key), 0.9);
 
   free(array);
 }
@@ -5981,16 +6098,16 @@ START_TEST(test_bucket_sort_5)
 
   bucket_sort(array, length, mul_plus_floor_float, compare_float);
 
-  ck_assert_float_eq(*((float *)array[0].key), 0);
-  ck_assert_float_eq(*((float *)array[1].key), 0.1);
-  ck_assert_float_eq(*((float *)array[2].key), 0.2);
-  ck_assert_float_eq(*((float *)array[3].key), 0.3);
-  ck_assert_float_eq(*((float *)array[4].key), 0.4);
-  ck_assert_float_eq(*((float *)array[5].key), 0.5);
-  ck_assert_float_eq(*((float *)array[6].key), 0.6);
-  ck_assert_float_eq(*((float *)array[7].key), 0.7);
-  ck_assert_float_eq(*((float *)array[8].key), 0.8);
-  ck_assert_float_eq(*((float *)array[9].key), 0.9);
+  ck_assert_float_eq(*((float*)array[0].key), 0);
+  ck_assert_float_eq(*((float*)array[1].key), 0.1);
+  ck_assert_float_eq(*((float*)array[2].key), 0.2);
+  ck_assert_float_eq(*((float*)array[3].key), 0.3);
+  ck_assert_float_eq(*((float*)array[4].key), 0.4);
+  ck_assert_float_eq(*((float*)array[5].key), 0.5);
+  ck_assert_float_eq(*((float*)array[6].key), 0.6);
+  ck_assert_float_eq(*((float*)array[7].key), 0.7);
+  ck_assert_float_eq(*((float*)array[8].key), 0.8);
+  ck_assert_float_eq(*((float*)array[9].key), 0.9);
 
   free(array);
 }
@@ -6024,14 +6141,14 @@ START_TEST(test_bucket_sort_6)
 
   bucket_sort(array, length, mul_plus_floor_float, compare_float);
 
-  ck_assert_float_eq(*((float *)array[0].key), 0.01);
-  ck_assert_float_eq(*((float *)array[1].key), 0.02);
-  ck_assert_float_eq(*((float *)array[2].key), 0.02);
-  ck_assert_float_eq(*((float *)array[3].key), 0.03);
-  ck_assert_float_eq(*((float *)array[4].key), 0.04);
-  ck_assert_float_eq(*((float *)array[5].key), 0.05);
-  ck_assert_float_eq(*((float *)array[6].key), 0.7);
-  ck_assert_float_eq(*((float *)array[7].key), 0.6);
+  ck_assert_float_eq(*((float*)array[0].key), 0.01);
+  ck_assert_float_eq(*((float*)array[1].key), 0.02);
+  ck_assert_float_eq(*((float*)array[2].key), 0.02);
+  ck_assert_float_eq(*((float*)array[3].key), 0.03);
+  ck_assert_float_eq(*((float*)array[4].key), 0.04);
+  ck_assert_float_eq(*((float*)array[5].key), 0.05);
+  ck_assert_float_eq(*((float*)array[6].key), 0.7);
+  ck_assert_float_eq(*((float*)array[7].key), 0.6);
 
   free(array);
 }
@@ -6077,20 +6194,20 @@ START_TEST(test_bucket_sort_7)
 
   bucket_sort(array, length, mul_plus_floor_float, compare_float);
 
-  ck_assert_float_eq(*((float *)array[0].key), 0);
-  ck_assert_float_eq(*((float *)array[1].key), 0.002);
-  ck_assert_float_eq(*((float *)array[2].key), 0.003);
-  ck_assert_float_eq(*((float *)array[3].key), 0.004);
-  ck_assert_float_eq(*((float *)array[4].key), 0.007);
-  ck_assert_float_eq(*((float *)array[5].key), 0.03);
-  ck_assert_float_eq(*((float *)array[6].key), 0.055);
-  ck_assert_float_eq(*((float *)array[7].key), 0.08);
-  ck_assert_float_eq(*((float *)array[8].key), 0.1);
-  ck_assert_float_eq(*((float *)array[9].key), 0.15);
-  ck_assert_float_eq(*((float *)array[10].key), 0.2);
-  ck_assert_float_eq(*((float *)array[11].key), 0.3);
-  ck_assert_float_eq(*((float *)array[12].key), 0.57);
-  ck_assert_float_eq(*((float *)array[13].key), 0.7);
+  ck_assert_float_eq(*((float*)array[0].key), 0);
+  ck_assert_float_eq(*((float*)array[1].key), 0.002);
+  ck_assert_float_eq(*((float*)array[2].key), 0.003);
+  ck_assert_float_eq(*((float*)array[3].key), 0.004);
+  ck_assert_float_eq(*((float*)array[4].key), 0.007);
+  ck_assert_float_eq(*((float*)array[5].key), 0.03);
+  ck_assert_float_eq(*((float*)array[6].key), 0.055);
+  ck_assert_float_eq(*((float*)array[7].key), 0.08);
+  ck_assert_float_eq(*((float*)array[8].key), 0.1);
+  ck_assert_float_eq(*((float*)array[9].key), 0.15);
+  ck_assert_float_eq(*((float*)array[10].key), 0.2);
+  ck_assert_float_eq(*((float*)array[11].key), 0.3);
+  ck_assert_float_eq(*((float*)array[12].key), 0.57);
+  ck_assert_float_eq(*((float*)array[13].key), 0.7);
 
   free(array);
 }
@@ -6114,7 +6231,7 @@ START_TEST(test_bucket_sort_8)
   k10 = 0.2;
   k11 = 0.15;
   k12 = 0.01;
-  
+
   array = malloc(length * sizeof(Register));
 
   array[0].key = &k1;
@@ -6132,18 +6249,18 @@ START_TEST(test_bucket_sort_8)
 
   bucket_sort(array, length, mul_plus_floor_float, compare_float);
 
-  ck_assert_float_eq(*((float *)array[0].key), 0.003);
-  ck_assert_float_eq(*((float *)array[1].key), 0.01);
-  ck_assert_float_eq(*((float *)array[2].key), 0.015);
-  ck_assert_float_eq(*((float *)array[3].key), 0.02);
-  ck_assert_float_eq(*((float *)array[4].key), 0.03);
-  ck_assert_float_eq(*((float *)array[5].key), 0.05);
-  ck_assert_float_eq(*((float *)array[6].key), 0.075);
-  ck_assert_float_eq(*((float *)array[7].key), 0.15);
-  ck_assert_float_eq(*((float *)array[8].key), 0.2);
-  ck_assert_float_eq(*((float *)array[9].key), 0.3);
-  ck_assert_float_eq(*((float *)array[10].key), 0.5);
-  ck_assert_float_eq(*((float *)array[11].key), 0.75);
+  ck_assert_float_eq(*((float*)array[0].key), 0.003);
+  ck_assert_float_eq(*((float*)array[1].key), 0.01);
+  ck_assert_float_eq(*((float*)array[2].key), 0.015);
+  ck_assert_float_eq(*((float*)array[3].key), 0.02);
+  ck_assert_float_eq(*((float*)array[4].key), 0.03);
+  ck_assert_float_eq(*((float*)array[5].key), 0.05);
+  ck_assert_float_eq(*((float*)array[6].key), 0.075);
+  ck_assert_float_eq(*((float*)array[7].key), 0.15);
+  ck_assert_float_eq(*((float*)array[8].key), 0.2);
+  ck_assert_float_eq(*((float*)array[9].key), 0.3);
+  ck_assert_float_eq(*((float*)array[10].key), 0.5);
+  ck_assert_float_eq(*((float*)array[11].key), 0.75);
 
   free(array);
 }
@@ -6172,12 +6289,12 @@ START_TEST(test_bucket_sort_9)
 
   bucket_sort(array, length, mul_plus_floor_double, compare_double);
 
-  ck_assert_double_eq(*((double *)array[0].key), 0.1);
-  ck_assert_double_eq(*((double *)array[1].key), 0.2);
-  ck_assert_double_eq(*((double *)array[2].key), 0.3);
-  ck_assert_double_eq(*((double *)array[3].key), 0.4);
-  ck_assert_double_eq(*((double *)array[4].key), 0.5);
-  ck_assert_double_eq(*((double *)array[5].key), 0.6);
+  ck_assert_double_eq(*((double*)array[0].key), 0.1);
+  ck_assert_double_eq(*((double*)array[1].key), 0.2);
+  ck_assert_double_eq(*((double*)array[2].key), 0.3);
+  ck_assert_double_eq(*((double*)array[3].key), 0.4);
+  ck_assert_double_eq(*((double*)array[4].key), 0.5);
+  ck_assert_double_eq(*((double*)array[5].key), 0.6);
 
   free(array);
 }
@@ -6217,17 +6334,17 @@ START_TEST(test_bucket_sort_10)
 
   bucket_sort(array, length, mul_plus_floor_double, compare_double);
 
-  ck_assert_double_eq(*((double *)array[0].key), 0);
-  ck_assert_double_eq(*((double *)array[1].key), 0.005);
-  ck_assert_double_eq(*((double *)array[2].key), 0.01);
-  ck_assert_double_eq(*((double *)array[3].key), 0.015);
-  ck_assert_double_eq(*((double *)array[4].key), 0.02);
-  ck_assert_double_eq(*((double *)array[5].key), 0.03);
-  ck_assert_double_eq(*((double *)array[6].key), 0.05);
-  ck_assert_double_eq(*((double *)array[7].key), 0.075);
-  ck_assert_double_eq(*((double *)array[8].key), 0.1);
-  ck_assert_double_eq(*((double *)array[9].key), 0.122);
-  ck_assert_double_eq(*((double *)array[10].key), 0.2);
+  ck_assert_double_eq(*((double*)array[0].key), 0);
+  ck_assert_double_eq(*((double*)array[1].key), 0.005);
+  ck_assert_double_eq(*((double*)array[2].key), 0.01);
+  ck_assert_double_eq(*((double*)array[3].key), 0.015);
+  ck_assert_double_eq(*((double*)array[4].key), 0.02);
+  ck_assert_double_eq(*((double*)array[5].key), 0.03);
+  ck_assert_double_eq(*((double*)array[6].key), 0.05);
+  ck_assert_double_eq(*((double*)array[7].key), 0.075);
+  ck_assert_double_eq(*((double*)array[8].key), 0.1);
+  ck_assert_double_eq(*((double*)array[9].key), 0.122);
+  ck_assert_double_eq(*((double*)array[10].key), 0.2);
 
   free(array);
 }
@@ -6265,16 +6382,16 @@ START_TEST(test_bucket_sort_11)
 
   bucket_sort(array, length, mul_plus_floor_double, compare_double);
 
-  ck_assert_double_eq(*((double *)array[0].key), 0);
-  ck_assert_double_eq(*((double *)array[1].key), 0.001);
-  ck_assert_double_eq(*((double *)array[2].key), 0.002);
-  ck_assert_double_eq(*((double *)array[3].key), 0.003);
-  ck_assert_double_eq(*((double *)array[4].key), 0.004);
-  ck_assert_double_eq(*((double *)array[5].key), 0.005);
-  ck_assert_double_eq(*((double *)array[6].key), 0.006);
-  ck_assert_double_eq(*((double *)array[7].key), 0.007);
-  ck_assert_double_eq(*((double *)array[8].key), 0.008);
-  ck_assert_double_eq(*((double *)array[9].key), 0.9);
+  ck_assert_double_eq(*((double*)array[0].key), 0);
+  ck_assert_double_eq(*((double*)array[1].key), 0.001);
+  ck_assert_double_eq(*((double*)array[2].key), 0.002);
+  ck_assert_double_eq(*((double*)array[3].key), 0.003);
+  ck_assert_double_eq(*((double*)array[4].key), 0.004);
+  ck_assert_double_eq(*((double*)array[5].key), 0.005);
+  ck_assert_double_eq(*((double*)array[6].key), 0.006);
+  ck_assert_double_eq(*((double*)array[7].key), 0.007);
+  ck_assert_double_eq(*((double*)array[8].key), 0.008);
+  ck_assert_double_eq(*((double*)array[9].key), 0.9);
 
   free(array);
 }
@@ -6309,28 +6426,28 @@ START_TEST(test_bucket_sort_12)
   array[7].key = &k8;
   array[8].key = &k9;
   array[9].key = &k10;
-  
+
   bucket_sort(array, length, mul_plus_floor_double, compare_double);
 
-  ck_assert_double_eq(*((double *)array[0].key), 0);
-  ck_assert_double_eq(*((double *)array[1].key), 0.1);
-  ck_assert_double_eq(*((double *)array[2].key), 0.2);
-  ck_assert_double_eq(*((double *)array[3].key), 0.3);
-  ck_assert_double_eq(*((double *)array[4].key), 0.4);
-  ck_assert_double_eq(*((double *)array[5].key), 0.5);
-  ck_assert_double_eq(*((double *)array[6].key), 0.6);
-  ck_assert_double_eq(*((double *)array[7].key), 0.7);
-  ck_assert_double_eq(*((double *)array[8].key), 0.8);
-  ck_assert_double_eq(*((double *)array[9].key), 0.9);
+  ck_assert_double_eq(*((double*)array[0].key), 0);
+  ck_assert_double_eq(*((double*)array[1].key), 0.1);
+  ck_assert_double_eq(*((double*)array[2].key), 0.2);
+  ck_assert_double_eq(*((double*)array[3].key), 0.3);
+  ck_assert_double_eq(*((double*)array[4].key), 0.4);
+  ck_assert_double_eq(*((double*)array[5].key), 0.5);
+  ck_assert_double_eq(*((double*)array[6].key), 0.6);
+  ck_assert_double_eq(*((double*)array[7].key), 0.7);
+  ck_assert_double_eq(*((double*)array[8].key), 0.8);
+  ck_assert_double_eq(*((double*)array[9].key), 0.9);
 
   free(array);
 }
 END_TEST
 
-Suite *make_test_suite(void)
+Suite* make_test_suite(void)
 {
-  Suite *s;
-  TCase *tc_core;
+  Suite* s;
+  TCase* tc_core;
 
   s = suite_create("Sorting Algorithms Test Suite");
 
@@ -6582,7 +6699,7 @@ Suite *make_test_suite(void)
   tcase_add_test(tc_core, test_bucket_sort_10);
   tcase_add_test(tc_core, test_bucket_sort_11);
   tcase_add_test(tc_core, test_bucket_sort_12);
-  
+
   suite_add_tcase(s, tc_core);
 
   return s;
@@ -6591,7 +6708,7 @@ Suite *make_test_suite(void)
 int main(void)
 {
   int number_failed;
-  SRunner *sr;
+  SRunner* sr;
 
   sr = srunner_create(make_test_suite());
   srunner_set_fork_status(sr, CK_NOFORK);

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -6,8 +6,30 @@
 #include <stdlib.h>
 
 Suite *make_test_suite(void);
+int compare(void *key1, void *key2);
 
 int seed = 23;
+
+int compare(void *key1, void *key2)
+{
+  int result;
+  int k1 = *((int *)key1);
+  int k2 = *((int *)key2);
+
+  if (k1 > k2)
+    {
+      result = 1;
+    }
+  else if (k1 < k2)
+    {
+      result = -1;
+    }
+  else
+    {
+      result = 0;
+    }
+  return result;
+}
 
 START_TEST(test_insertion_sort_1)
 {
@@ -3810,6 +3832,728 @@ START_TEST(test_radix_sort_12)
 }
 END_TEST
 
+START_TEST(test_insertion_sort_gnrc_1)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6;
+  int length = 6;
+  int start = 0;
+  int end = 5;
+
+  k1 = 5;
+  k2 = 2;
+  k3 = 4;
+  k4 = 6;
+  k5 = 1;
+  k6 = 3;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 1);
+  ck_assert_int_eq(*((int *)array[1].key), 2);
+  ck_assert_int_eq(*((int *)array[2].key), 3);
+  ck_assert_int_eq(*((int *)array[3].key), 4);
+  ck_assert_int_eq(*((int *)array[4].key), 5);
+  ck_assert_int_eq(*((int *)array[5].key), 6);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_2)
+{
+  Register *array;
+  int k1 = 5;
+  int length = 1;
+  int start = 0;
+  int end = 0;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 5);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_3)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11;
+  int length = 11;
+  int start = 0;
+  int end = 10;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = -10;
+  k2 = 15;
+  k3 = -5;
+  k4 = -20;
+  k5 = 50;
+  k6 = 0;
+  k7 = 100;
+  k8 = 75;
+  k9 = 30;
+  k10 = 200;
+  k11 = -200;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  array[10].key = &k11;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), -200);
+  ck_assert_int_eq(*((int *)array[1].key), -20);
+  ck_assert_int_eq(*((int *)array[2].key), -10);
+  ck_assert_int_eq(*((int *)array[3].key), -5);
+  ck_assert_int_eq(*((int *)array[4].key), 0);
+  ck_assert_int_eq(*((int *)array[5].key), 15);
+  ck_assert_int_eq(*((int *)array[6].key), 30);
+  ck_assert_int_eq(*((int *)array[7].key), 50);
+  ck_assert_int_eq(*((int *)array[8].key), 75);
+  ck_assert_int_eq(*((int *)array[9].key), 100);
+  ck_assert_int_eq(*((int *)array[10].key), 200);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_4)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  int length = 10;
+  int start = 0;
+  int end = 9;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 0;
+  k2 = 1;
+  k3 = 2;
+  k4 = 3;
+  k5 = 4;
+  k6 = 5;
+  k7 = 6;
+  k8 = 7;
+  k9 = 8;
+  k10 = 9;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 0);
+  ck_assert_int_eq(*((int *)array[1].key), 1);
+  ck_assert_int_eq(*((int *)array[2].key), 2);
+  ck_assert_int_eq(*((int *)array[3].key), 3);
+  ck_assert_int_eq(*((int *)array[4].key), 4);
+  ck_assert_int_eq(*((int *)array[5].key), 5);
+  ck_assert_int_eq(*((int *)array[6].key), 6);
+  ck_assert_int_eq(*((int *)array[7].key), 7);
+  ck_assert_int_eq(*((int *)array[8].key), 8);
+  ck_assert_int_eq(*((int *)array[9].key), 9);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_5)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  int length = 10;
+  int start = 0;
+  int end = 9;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 9;
+  k2 = 8;
+  k3 = 7;
+  k4 = 6;
+  k5 = 5;
+  k6 = 4;
+  k7 = 3;
+  k8 = 2;
+  k9 = 1;
+  k10 = 0;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 0);
+  ck_assert_int_eq(*((int *)array[1].key), 1);
+  ck_assert_int_eq(*((int *)array[2].key), 2);
+  ck_assert_int_eq(*((int *)array[3].key), 3);
+  ck_assert_int_eq(*((int *)array[4].key), 4);
+  ck_assert_int_eq(*((int *)array[5].key), 5);
+  ck_assert_int_eq(*((int *)array[6].key), 6);
+  ck_assert_int_eq(*((int *)array[7].key), 7);
+  ck_assert_int_eq(*((int *)array[8].key), 8);
+  ck_assert_int_eq(*((int *)array[9].key), 9);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_6)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8;
+  int length = 8;
+  int start = 2;
+  int end = 7;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 2;
+  k2 = 4;
+  k3 = 1;
+  k4 = 5;
+  k5 = 7;
+  k6 = 2;
+  k7 = 3;
+  k8 = 6;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 2);
+  ck_assert_int_eq(*((int *)array[1].key), 4);
+  ck_assert_int_eq(*((int *)array[2].key), 1);
+  ck_assert_int_eq(*((int *)array[3].key), 2);
+  ck_assert_int_eq(*((int *)array[4].key), 3);
+  ck_assert_int_eq(*((int *)array[5].key), 5);
+  ck_assert_int_eq(*((int *)array[6].key), 6);
+  ck_assert_int_eq(*((int *)array[7].key), 7);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_7)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8;
+  int length = 8;
+  int start = 0;
+  int end = 5;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 2;
+  k2 = 4;
+  k3 = 5;
+  k4 = 1;
+  k5 = 2;
+  k6 = 3;
+  k7 = 7;
+  k8 = 6;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 1);
+  ck_assert_int_eq(*((int *)array[1].key), 2);
+  ck_assert_int_eq(*((int *)array[2].key), 2);
+  ck_assert_int_eq(*((int *)array[3].key), 3);
+  ck_assert_int_eq(*((int *)array[4].key), 4);
+  ck_assert_int_eq(*((int *)array[5].key), 5);
+  ck_assert_int_eq(*((int *)array[6].key), 7);
+  ck_assert_int_eq(*((int *)array[7].key), 6);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_8)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8;
+  int length = 8;
+  int start = 2;
+  int end = 5;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 2;
+  k2 = 4;
+  k3 = 1;
+  k4 = 5;
+  k5 = 2;
+  k6 = 3;
+  k7 = 7;
+  k8 = 6;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 2);
+  ck_assert_int_eq(*((int *)array[1].key), 4);
+  ck_assert_int_eq(*((int *)array[2].key), 1);
+  ck_assert_int_eq(*((int *)array[3].key), 2);
+  ck_assert_int_eq(*((int *)array[4].key), 3);
+  ck_assert_int_eq(*((int *)array[5].key), 5);
+  ck_assert_int_eq(*((int *)array[6].key), 7);
+  ck_assert_int_eq(*((int *)array[7].key), 6);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_9)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14;
+  int length = 14;
+  int start = 0;
+  int end = 13;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 0;
+  k2 = 2;
+  k3 = 3;
+  k4 = 4;
+  k5 = 55;
+  k6 = 300;
+  k7 = 700;
+  k8 = -200;
+  k9 = -100;
+  k10 = -80;
+  k11 = -7;
+  k12 = 30;
+  k13 = 150;
+  k14 = 570;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  array[10].key = &k11;
+  array[11].key = &k12;
+  array[12].key = &k13;
+  array[13].key = &k14;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), -200);
+  ck_assert_int_eq(*((int *)array[1].key), -100);
+  ck_assert_int_eq(*((int *)array[2].key), -80);
+  ck_assert_int_eq(*((int *)array[3].key), -7);
+  ck_assert_int_eq(*((int *)array[4].key), 0);
+  ck_assert_int_eq(*((int *)array[5].key), 2);
+  ck_assert_int_eq(*((int *)array[6].key), 3);
+  ck_assert_int_eq(*((int *)array[7].key), 4);
+  ck_assert_int_eq(*((int *)array[8].key), 30);
+  ck_assert_int_eq(*((int *)array[9].key), 55);
+  ck_assert_int_eq(*((int *)array[10].key), 150);
+  ck_assert_int_eq(*((int *)array[11].key), 300);
+  ck_assert_int_eq(*((int *)array[12].key), 570);
+  ck_assert_int_eq(*((int *)array[13].key), 700);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_10)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14;
+  int length = 14;
+  int start = 2;
+  int end = 11;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 0;
+  k2 = 2;
+  k3 = 3;
+  k4 = 4;
+  k5 = 55;
+  k6 = 300;
+  k7 = 700;
+  k8 = -200;
+  k9 = -100;
+  k10 = -80;
+  k11 = -7;
+  k12 = 30;
+  k13 = 150;
+  k14 = 570;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  array[10].key = &k11;
+  array[11].key = &k12;
+  array[12].key = &k13;
+  array[13].key = &k14;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 0);
+  ck_assert_int_eq(*((int *)array[1].key), 2);
+  ck_assert_int_eq(*((int *)array[2].key), -200);
+  ck_assert_int_eq(*((int *)array[3].key), -100);
+  ck_assert_int_eq(*((int *)array[4].key), -80);
+  ck_assert_int_eq(*((int *)array[5].key), -7);
+  ck_assert_int_eq(*((int *)array[6].key), 3);
+  ck_assert_int_eq(*((int *)array[7].key), 4);
+  ck_assert_int_eq(*((int *)array[8].key), 30);
+  ck_assert_int_eq(*((int *)array[9].key), 55);
+  ck_assert_int_eq(*((int *)array[10].key), 300);
+  ck_assert_int_eq(*((int *)array[11].key), 700);
+  ck_assert_int_eq(*((int *)array[12].key), 150);
+  ck_assert_int_eq(*((int *)array[13].key), 570);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_11)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12;
+  int length = 12;
+  int start = 0;
+  int end = 11;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 3;
+  k2 = 15;
+  k3 = 20;
+  k4 = 30;
+  k5 = 50;
+  k6 = 75;
+  k7 = -75;
+  k8 = -50;
+  k9 = -30;
+  k10 = -20;
+  k11 = -15;
+  k12 = -3;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  array[10].key = &k11;
+  array[11].key = &k12;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), -75);
+  ck_assert_int_eq(*((int *)array[1].key), -50);
+  ck_assert_int_eq(*((int *)array[2].key), -30);
+  ck_assert_int_eq(*((int *)array[3].key), -20);
+  ck_assert_int_eq(*((int *)array[4].key), -15);
+  ck_assert_int_eq(*((int *)array[5].key), -3);
+  ck_assert_int_eq(*((int *)array[6].key), 3);
+  ck_assert_int_eq(*((int *)array[7].key), 15);
+  ck_assert_int_eq(*((int *)array[8].key), 20);
+  ck_assert_int_eq(*((int *)array[9].key), 30);
+  ck_assert_int_eq(*((int *)array[10].key), 50);
+  ck_assert_int_eq(*((int *)array[11].key), 75);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_12)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6;
+  int length = 6;
+  int start = 0;
+  int end = 5;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 5;
+  k2 = 2;
+  k3 = 4;
+  k4 = 6;
+  k5 = 1;
+  k6 = 3;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 1);
+  ck_assert_int_eq(*((int *)array[1].key), 2);
+  ck_assert_int_eq(*((int *)array[2].key), 3);
+  ck_assert_int_eq(*((int *)array[3].key), 4);
+  ck_assert_int_eq(*((int *)array[4].key), 5);
+  ck_assert_int_eq(*((int *)array[5].key), 6);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_13)
+{
+  Register *array;
+  int k1;
+  int length = 1;
+  int start = 0;
+  int end = 0;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 5;
+
+  array[0].key = &k1;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 5);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_14)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11;
+  int length = 11;
+  int start = 0;
+  int end = 10;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = -10;
+  k2 = 15;
+  k3 = -5;
+  k4 = -20;
+  k5 = 50;
+  k6 = 0;
+  k7 = 100;
+  k8 = 75;
+  k9 = 30;
+  k10 = 200;
+  k11 = -200;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  array[10].key = &k11;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), -200);
+  ck_assert_int_eq(*((int *)array[1].key), -20);
+  ck_assert_int_eq(*((int *)array[2].key), -10);
+  ck_assert_int_eq(*((int *)array[3].key), -5);
+  ck_assert_int_eq(*((int *)array[4].key), 0);
+  ck_assert_int_eq(*((int *)array[5].key), 15);
+  ck_assert_int_eq(*((int *)array[6].key), 30);
+  ck_assert_int_eq(*((int *)array[7].key), 50);
+  ck_assert_int_eq(*((int *)array[8].key), 75);
+  ck_assert_int_eq(*((int *)array[9].key), 100);
+  ck_assert_int_eq(*((int *)array[10].key), 200);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_15)
+{
+  Register *array;
+  int length = 10;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  int start = 0;
+  int end = 9;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 0;
+  k2 = 1;
+  k3 = 2;
+  k4 = 3;
+  k5 = 4;
+  k6 = 5;
+  k7 = 6;
+  k8 = 7;
+  k9 = 8;
+  k10 = 9;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 0);
+  ck_assert_int_eq(*((int *)array[1].key), 1);
+  ck_assert_int_eq(*((int *)array[2].key), 2);
+  ck_assert_int_eq(*((int *)array[3].key), 3);
+  ck_assert_int_eq(*((int *)array[4].key), 4);
+  ck_assert_int_eq(*((int *)array[5].key), 5);
+  ck_assert_int_eq(*((int *)array[6].key), 6);
+  ck_assert_int_eq(*((int *)array[7].key), 7);
+  ck_assert_int_eq(*((int *)array[8].key), 8);
+  ck_assert_int_eq(*((int *)array[9].key), 9);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_insertion_sort_gnrc_16)
+{
+  Register *array;
+  int k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  int length = 10;
+  int start = 0;
+  int end = 9;
+
+  array = malloc(length * sizeof(Register));
+
+  k1 = 9;
+  k2 = 8;
+  k3 = 7;
+  k4 = 6;
+  k5 = 5;
+  k6 = 4;
+  k7 = 3;
+  k8 = 2;
+  k9 = 1;
+  k10 = 0;
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+
+  insertion_sort_gnrc(array, start, end, compare);
+
+  ck_assert_int_eq(*((int *)array[0].key), 0);
+  ck_assert_int_eq(*((int *)array[1].key), 1);
+  ck_assert_int_eq(*((int *)array[2].key), 2);
+  ck_assert_int_eq(*((int *)array[3].key), 3);
+  ck_assert_int_eq(*((int *)array[4].key), 4);
+  ck_assert_int_eq(*((int *)array[5].key), 5);
+  ck_assert_int_eq(*((int *)array[6].key), 6);
+  ck_assert_int_eq(*((int *)array[7].key), 7);
+  ck_assert_int_eq(*((int *)array[8].key), 8);
+  ck_assert_int_eq(*((int *)array[9].key), 9);
+
+  free(array);
+}
+END_TEST
+
 Suite *make_test_suite(void)
 {
   Suite *s;
@@ -4018,6 +4762,23 @@ Suite *make_test_suite(void)
   tcase_add_test(tc_core, test_radix_sort_10);
   tcase_add_test(tc_core, test_radix_sort_11);
   tcase_add_test(tc_core, test_radix_sort_12);
+
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_1);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_2);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_3);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_4);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_5);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_6);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_7);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_8);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_9);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_10);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_11);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_12);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_13);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_14);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_15);
+  tcase_add_test(tc_core, test_insertion_sort_gnrc_16);
 
   suite_add_tcase(s, tc_core);
 

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -4,13 +4,18 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <math.h>
 
 Suite *make_test_suite(void);
-int compare(void *key1, void *key2);
+int compare_int(void* key1, void* key2);
+int compare_float(void* key1, void* key2);
+int compare_double(void* key1, void* key2);
+int mul_plus_floor_float(int n, void* key);
+int mul_plus_floor_double(int n, void* key);
 
 int seed = 23;
 
-int compare(void *key1, void *key2)
+int compare_int(void* key1, void* key2)
 {
   int result;
   int k1 = *((int *)key1);
@@ -28,6 +33,68 @@ int compare(void *key1, void *key2)
     {
       result = 0;
     }
+  return result;
+}
+
+int compare_float(void* key1, void* key2)
+{
+  int result;
+  float k1 = *((float *)key1);
+  float k2 = *((float *)key2);
+
+  if (k1 > k2)
+    {
+      result = 1;
+    }
+  else if (k1 < k2)
+    {
+      result = -1;
+    }
+  else
+    {
+      result = 0;
+    }
+  return result;
+}
+
+int compare_double(void* key1, void* key2)
+{
+  int result;
+  double k1 = *((double *)key1);
+  double k2 = *((double *)key2);
+
+  if (k1 > k2)
+    {
+      result = 1;
+    }
+  else if (k1 < k2)
+    {
+      result = -1;
+    }
+  else
+    {
+      result = 0;
+    }
+  return result;
+}
+
+int mul_plus_floor_float(int n, void* key)
+{
+  int result;
+  float temp = *((float *)key);
+  temp = floor(n * temp);
+  result = (int) temp;
+
+  return result;
+}
+
+int mul_plus_floor_double(int n, void* key)
+{
+  int result;
+  double temp = *((double *)key);
+  temp = floor(n * temp);
+  result = (int) temp;
+
   return result;
 }
 
@@ -3856,7 +3923,7 @@ START_TEST(test_insertion_sort_gnrc_1)
   array[4].key = &k5;
   array[5].key = &k6;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 1);
   ck_assert_int_eq(*((int *)array[1].key), 2);
@@ -3881,7 +3948,7 @@ START_TEST(test_insertion_sort_gnrc_2)
 
   array[0].key = &k1;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 5);
 
@@ -3923,7 +3990,7 @@ START_TEST(test_insertion_sort_gnrc_3)
   array[9].key = &k10;
   array[10].key = &k11;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), -200);
   ck_assert_int_eq(*((int *)array[1].key), -20);
@@ -3973,7 +4040,7 @@ START_TEST(test_insertion_sort_gnrc_4)
   array[8].key = &k9;
   array[9].key = &k10;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 0);
   ck_assert_int_eq(*((int *)array[1].key), 1);
@@ -4022,7 +4089,7 @@ START_TEST(test_insertion_sort_gnrc_5)
   array[8].key = &k9;
   array[9].key = &k10;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 0);
   ck_assert_int_eq(*((int *)array[1].key), 1);
@@ -4067,7 +4134,7 @@ START_TEST(test_insertion_sort_gnrc_6)
   array[6].key = &k7;
   array[7].key = &k8;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 2);
   ck_assert_int_eq(*((int *)array[1].key), 4);
@@ -4110,7 +4177,7 @@ START_TEST(test_insertion_sort_gnrc_7)
   array[6].key = &k7;
   array[7].key = &k8;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 1);
   ck_assert_int_eq(*((int *)array[1].key), 2);
@@ -4153,7 +4220,7 @@ START_TEST(test_insertion_sort_gnrc_8)
   array[6].key = &k7;
   array[7].key = &k8;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 2);
   ck_assert_int_eq(*((int *)array[1].key), 4);
@@ -4208,7 +4275,7 @@ START_TEST(test_insertion_sort_gnrc_9)
   array[12].key = &k13;
   array[13].key = &k14;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), -200);
   ck_assert_int_eq(*((int *)array[1].key), -100);
@@ -4269,7 +4336,7 @@ START_TEST(test_insertion_sort_gnrc_10)
   array[12].key = &k13;
   array[13].key = &k14;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 0);
   ck_assert_int_eq(*((int *)array[1].key), 2);
@@ -4326,7 +4393,7 @@ START_TEST(test_insertion_sort_gnrc_11)
   array[10].key = &k11;
   array[11].key = &k12;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), -75);
   ck_assert_int_eq(*((int *)array[1].key), -50);
@@ -4369,7 +4436,7 @@ START_TEST(test_insertion_sort_gnrc_12)
   array[4].key = &k5;
   array[5].key = &k6;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 1);
   ck_assert_int_eq(*((int *)array[1].key), 2);
@@ -4396,7 +4463,7 @@ START_TEST(test_insertion_sort_gnrc_13)
 
   array[0].key = &k1;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 5);
 
@@ -4438,7 +4505,7 @@ START_TEST(test_insertion_sort_gnrc_14)
   array[9].key = &k10;
   array[10].key = &k11;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), -200);
   ck_assert_int_eq(*((int *)array[1].key), -20);
@@ -4488,7 +4555,7 @@ START_TEST(test_insertion_sort_gnrc_15)
   array[8].key = &k9;
   array[9].key = &k10;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 0);
   ck_assert_int_eq(*((int *)array[1].key), 1);
@@ -4537,7 +4604,7 @@ START_TEST(test_insertion_sort_gnrc_16)
   array[8].key = &k9;
   array[9].key = &k10;
 
-  insertion_sort_gnrc(array, start, end, compare);
+  insertion_sort_gnrc(array, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)array[0].key), 0);
   ck_assert_int_eq(*((int *)array[1].key), 1);
@@ -4592,7 +4659,7 @@ START_TEST(test_insertion_sort_dll_1)
   reg.key = &k6;
   node6 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 1);
   
@@ -4628,7 +4695,7 @@ START_TEST(test_insertion_sort_dll_2)
   reg.key = &k1;
   node1 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 5);
   ck_assert_int_eq(*((int *)node1->data.key), 5);
@@ -4696,7 +4763,7 @@ START_TEST(test_insertion_sort_dll_3)
   reg.key = &k11;
   node11 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), -200);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), -20);
@@ -4779,7 +4846,7 @@ START_TEST(test_insertion_sort_dll_4)
   reg.key = &k10;
   node10 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 0);
@@ -4861,7 +4928,7 @@ START_TEST(test_insertion_sort_dll_5)
   reg.key = &k10;
   node10 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 0);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
@@ -4934,7 +5001,7 @@ START_TEST(test_insertion_sort_dll_6)
   reg.key = &k1;
   node8 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 2);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), 4);
@@ -5003,7 +5070,7 @@ START_TEST(test_insertion_sort_dll_7)
   reg.key = &k1;
   node8 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 1);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
@@ -5072,7 +5139,7 @@ START_TEST(test_insertion_sort_dll_8)
   reg.key = &k1;
   node8 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 2);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), 4);
@@ -5165,7 +5232,7 @@ START_TEST(test_insertion_sort_dll_9)
   reg.key = &k1;
   node14 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), -200);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), -100);
@@ -5270,7 +5337,7 @@ START_TEST(test_insertion_sort_dll_10)
   reg.key = &k1;
   node14 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 0);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
@@ -5367,7 +5434,7 @@ START_TEST(test_insertion_sort_dll_11)
   reg.key = &k1;
   node12 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), -75);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), -50);
@@ -5436,7 +5503,7 @@ START_TEST(test_insertion_sort_dll_12)
   reg.key = &k1;
   node6 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 1);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), 2);
@@ -5472,7 +5539,7 @@ START_TEST(test_insertion_sort_dll_13)
   reg.key = &k1;
   node1 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 5);
 
@@ -5539,7 +5606,7 @@ START_TEST(test_insertion_sort_dll_14)
   reg.key = &k11;
   node11 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), -200);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), -20);
@@ -5622,7 +5689,7 @@ START_TEST(test_insertion_sort_dll_15)
   reg.key = &k10;
   node10 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_int);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 0);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
@@ -5703,7 +5770,7 @@ START_TEST(test_insertion_sort_dll_16)
   reg.key = &k10;
   node10 = dll_insert(head, reg);
 
-  insertion_sort_dll(head, start, end, compare);
+  insertion_sort_dll(head, start, end, compare_float);
 
   ck_assert_int_eq(*((int *)(*head)->data.key), 0);
   ck_assert_int_eq(*((int *)(*head)->next->data.key), 1);
@@ -5727,6 +5794,536 @@ START_TEST(test_insertion_sort_dll_16)
   free(node2);
   free(node1);
   free(head);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_1)
+{
+  Register* array;
+  float k1, k2, k3, k4, k5, k6;
+  int length = 6;
+
+  k1 = 0.5;
+  k2 = 0.2;
+  k3 = 0.4;
+  k4 = 0.6;
+  k5 = 0.1;
+  k6 = 0.3;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+
+  bucket_sort(array, length, mul_plus_floor_float, compare_float);
+
+  ck_assert_float_eq(*((float *)array[0].key), 0.1);
+  ck_assert_float_eq(*((float *)array[1].key), 0.2);
+  ck_assert_float_eq(*((float *)array[2].key), 0.3);
+  ck_assert_float_eq(*((float *)array[3].key), 0.4);
+  ck_assert_float_eq(*((float *)array[4].key), 0.5);
+  ck_assert_float_eq(*((float *)array[5].key), 0.6);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_2)
+{
+  Register* array;
+  float k1;
+  int length = 1;
+
+  k1 = 0.5;
+  
+  array = malloc(length * sizeof(Register));
+  
+  array[0].key = &k1;
+  
+  bucket_sort(array, length, mul_plus_floor_float, compare_float);
+
+  ck_assert_float_eq(*((float *)array[0].key), 0.5);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_3)
+{
+  Register* array;
+  float k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11;
+  int length = 11;
+
+  k1 = 0.01;
+  k2 = 0.015;
+  k3 = 0.005;
+  k4 = 0.02;
+  k5 = 0.05;
+  k6 = 0;
+  k7 = 0.1;
+  k8 = 0.075;
+  k9 = 0.03;
+  k10 = 0.2;
+  k11 = 0.002;
+
+  array = malloc(length * sizeof(Register));
+  
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  array[10].key = &k11;
+
+  bucket_sort(array, length, mul_plus_floor_float, compare_float);
+
+  ck_assert_float_eq(*((float *)array[0].key), 0);
+  ck_assert_float_eq(*((float *)array[1].key), 0.002);
+  ck_assert_float_eq(*((float *)array[2].key), 0.005);
+  ck_assert_float_eq(*((float *)array[3].key), 0.01);
+  ck_assert_float_eq(*((float *)array[4].key), 0.015);
+  ck_assert_float_eq(*((float *)array[5].key), 0.02);
+  ck_assert_float_eq(*((float *)array[6].key), 0.03);
+  ck_assert_float_eq(*((float *)array[7].key), 0.05);
+  ck_assert_float_eq(*((float *)array[8].key), 0.075);
+  ck_assert_float_eq(*((float *)array[9].key), 0.1);
+  ck_assert_float_eq(*((float *)array[10].key), 0.2);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_4)
+{
+  Register* array;
+  float k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  int length = 10;
+
+  k1 = 0;
+  k2 = 0.1;
+  k3 = 0.2;
+  k4 = 0.3;
+  k5 = 0.4;
+  k6 = 0.5;
+  k7 = 0.6;
+  k8 = 0.7;
+  k9 = 0.8;
+  k10 = 0.9;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+
+  bucket_sort(array, length, mul_plus_floor_float, compare_float);
+
+  ck_assert_float_eq(*((float *)array[0].key), 0);
+  ck_assert_float_eq(*((float *)array[1].key), 0.1);
+  ck_assert_float_eq(*((float *)array[2].key), 0.2);
+  ck_assert_float_eq(*((float *)array[3].key), 0.3);
+  ck_assert_float_eq(*((float *)array[4].key), 0.4);
+  ck_assert_float_eq(*((float *)array[5].key), 0.5);
+  ck_assert_float_eq(*((float *)array[6].key), 0.6);
+  ck_assert_float_eq(*((float *)array[7].key), 0.7);
+  ck_assert_float_eq(*((float *)array[8].key), 0.8);
+  ck_assert_float_eq(*((float *)array[9].key), 0.9);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_5)
+{
+  Register* array;
+  float k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  int length = 10;
+
+  k1 = 0.9;
+  k2 = 0.8;
+  k3 = 0.7;
+  k4 = 0.6;
+  k5 = 0.5;
+  k6 = 0.4;
+  k7 = 0.3;
+  k8 = 0.2;
+  k9 = 0.1;
+  k10 = 0;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+
+  bucket_sort(array, length, mul_plus_floor_float, compare_float);
+
+  ck_assert_float_eq(*((float *)array[0].key), 0);
+  ck_assert_float_eq(*((float *)array[1].key), 0.1);
+  ck_assert_float_eq(*((float *)array[2].key), 0.2);
+  ck_assert_float_eq(*((float *)array[3].key), 0.3);
+  ck_assert_float_eq(*((float *)array[4].key), 0.4);
+  ck_assert_float_eq(*((float *)array[5].key), 0.5);
+  ck_assert_float_eq(*((float *)array[6].key), 0.6);
+  ck_assert_float_eq(*((float *)array[7].key), 0.7);
+  ck_assert_float_eq(*((float *)array[8].key), 0.8);
+  ck_assert_float_eq(*((float *)array[9].key), 0.9);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_6)
+{
+  Register* array;
+  float k1, k2, k3, k4, k5, k6, k7, k8;
+  int length = 6;
+
+  k1 = 0.02;
+  k2 = 0.04;
+  k3 = 0.05;
+  k4 = 0.01;
+  k5 = 0.02;
+  k6 = 0.03;
+  k7 = 0.7;
+  k8 = 0.6;
+
+  array = malloc((length + 2) * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+
+  bucket_sort(array, length, mul_plus_floor_float, compare_float);
+
+  ck_assert_float_eq(*((float *)array[0].key), 0.01);
+  ck_assert_float_eq(*((float *)array[1].key), 0.02);
+  ck_assert_float_eq(*((float *)array[2].key), 0.02);
+  ck_assert_float_eq(*((float *)array[3].key), 0.03);
+  ck_assert_float_eq(*((float *)array[4].key), 0.04);
+  ck_assert_float_eq(*((float *)array[5].key), 0.05);
+  ck_assert_float_eq(*((float *)array[6].key), 0.7);
+  ck_assert_float_eq(*((float *)array[7].key), 0.6);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_7)
+{
+  Register* array;
+  float k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14;
+  int length = 14;
+
+  k1 = 0;
+  k2 = 0.004;
+  k3 = 0.002;
+  k4 = 0.055;
+  k5 = 0.3;
+  k6 = 0.003;
+  k7 = 0.7;
+  k8 = 0.2;
+  k9 = 0.1;
+  k10 = 0.08;
+  k11 = 0.007;
+  k12 = 0.03;
+  k13 = 0.15;
+  k14 = 0.57;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  array[10].key = &k11;
+  array[11].key = &k12;
+  array[12].key = &k13;
+  array[13].key = &k14;
+
+  bucket_sort(array, length, mul_plus_floor_float, compare_float);
+
+  ck_assert_float_eq(*((float *)array[0].key), 0);
+  ck_assert_float_eq(*((float *)array[1].key), 0.002);
+  ck_assert_float_eq(*((float *)array[2].key), 0.003);
+  ck_assert_float_eq(*((float *)array[3].key), 0.004);
+  ck_assert_float_eq(*((float *)array[4].key), 0.007);
+  ck_assert_float_eq(*((float *)array[5].key), 0.03);
+  ck_assert_float_eq(*((float *)array[6].key), 0.055);
+  ck_assert_float_eq(*((float *)array[7].key), 0.08);
+  ck_assert_float_eq(*((float *)array[8].key), 0.1);
+  ck_assert_float_eq(*((float *)array[9].key), 0.15);
+  ck_assert_float_eq(*((float *)array[10].key), 0.2);
+  ck_assert_float_eq(*((float *)array[11].key), 0.3);
+  ck_assert_float_eq(*((float *)array[12].key), 0.57);
+  ck_assert_float_eq(*((float *)array[13].key), 0.7);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_8)
+{
+  Register* array;
+  float k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12;
+  int length = 12;
+
+  k1 = 0.003;
+  k2 = 0.015;
+  k3 = 0.02;
+  k4 = 0.03;
+  k5 = 0.05;
+  k6 = 0.075;
+  k7 = 0.75;
+  k8 = 0.5;
+  k9 = 0.3;
+  k10 = 0.2;
+  k11 = 0.15;
+  k12 = 0.01;
+  
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  array[10].key = &k11;
+  array[11].key = &k12;
+
+  bucket_sort(array, length, mul_plus_floor_float, compare_float);
+
+  ck_assert_float_eq(*((float *)array[0].key), 0.003);
+  ck_assert_float_eq(*((float *)array[1].key), 0.01);
+  ck_assert_float_eq(*((float *)array[2].key), 0.015);
+  ck_assert_float_eq(*((float *)array[3].key), 0.02);
+  ck_assert_float_eq(*((float *)array[4].key), 0.03);
+  ck_assert_float_eq(*((float *)array[5].key), 0.05);
+  ck_assert_float_eq(*((float *)array[6].key), 0.075);
+  ck_assert_float_eq(*((float *)array[7].key), 0.15);
+  ck_assert_float_eq(*((float *)array[8].key), 0.2);
+  ck_assert_float_eq(*((float *)array[9].key), 0.3);
+  ck_assert_float_eq(*((float *)array[10].key), 0.5);
+  ck_assert_float_eq(*((float *)array[11].key), 0.75);
+
+  free(array);
+}
+
+START_TEST(test_bucket_sort_9)
+{
+  Register* array;
+  double k1, k2, k3, k4, k5, k6;
+  int length = 6;
+
+  k1 = 0.5;
+  k2 = 0.2;
+  k3 = 0.4;
+  k4 = 0.6;
+  k5 = 0.1;
+  k6 = 0.3;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+
+  bucket_sort(array, length, mul_plus_floor_double, compare_double);
+
+  ck_assert_double_eq(*((double *)array[0].key), 0.1);
+  ck_assert_double_eq(*((double *)array[1].key), 0.2);
+  ck_assert_double_eq(*((double *)array[2].key), 0.3);
+  ck_assert_double_eq(*((double *)array[3].key), 0.4);
+  ck_assert_double_eq(*((double *)array[4].key), 0.5);
+  ck_assert_double_eq(*((double *)array[5].key), 0.6);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_10)
+{
+  Register* array;
+  double k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11;
+  int length = 11;
+
+  k1 = 0.01;
+  k2 = 0.015;
+  k3 = 0.005;
+  k4 = 0.02;
+  k5 = 0.05;
+  k6 = 0;
+  k7 = 0.1;
+  k8 = 0.075;
+  k9 = 0.03;
+  k10 = 0.2;
+  k11 = 0.122;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  array[10].key = &k11;
+
+  bucket_sort(array, length, mul_plus_floor_double, compare_double);
+
+  ck_assert_double_eq(*((double *)array[0].key), 0);
+  ck_assert_double_eq(*((double *)array[1].key), 0.005);
+  ck_assert_double_eq(*((double *)array[2].key), 0.01);
+  ck_assert_double_eq(*((double *)array[3].key), 0.015);
+  ck_assert_double_eq(*((double *)array[4].key), 0.02);
+  ck_assert_double_eq(*((double *)array[5].key), 0.03);
+  ck_assert_double_eq(*((double *)array[6].key), 0.05);
+  ck_assert_double_eq(*((double *)array[7].key), 0.075);
+  ck_assert_double_eq(*((double *)array[8].key), 0.1);
+  ck_assert_double_eq(*((double *)array[9].key), 0.122);
+  ck_assert_double_eq(*((double *)array[10].key), 0.2);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_11)
+{
+  Register* array;
+  double k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  int length = 10;
+
+  k1 = 0;
+  k2 = 0.001;
+  k3 = 0.002;
+  k4 = 0.003;
+  k5 = 0.004;
+  k6 = 0.005;
+  k7 = 0.006;
+  k8 = 0.007;
+  k9 = 0.008;
+  k10 = 0.9;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+
+  bucket_sort(array, length, mul_plus_floor_double, compare_double);
+
+  ck_assert_double_eq(*((double *)array[0].key), 0);
+  ck_assert_double_eq(*((double *)array[1].key), 0.001);
+  ck_assert_double_eq(*((double *)array[2].key), 0.002);
+  ck_assert_double_eq(*((double *)array[3].key), 0.003);
+  ck_assert_double_eq(*((double *)array[4].key), 0.004);
+  ck_assert_double_eq(*((double *)array[5].key), 0.005);
+  ck_assert_double_eq(*((double *)array[6].key), 0.006);
+  ck_assert_double_eq(*((double *)array[7].key), 0.007);
+  ck_assert_double_eq(*((double *)array[8].key), 0.008);
+  ck_assert_double_eq(*((double *)array[9].key), 0.9);
+
+  free(array);
+}
+END_TEST
+
+START_TEST(test_bucket_sort_12)
+{
+  Register* array;
+  double k1, k2, k3, k4, k5, k6, k7, k8, k9, k10;
+  int length = 10;
+
+  k1 = 0.9;
+  k2 = 0.8;
+  k3 = 0.7;
+  k4 = 0.6;
+  k5 = 0.5;
+  k6 = 0.4;
+  k7 = 0.3;
+  k8 = 0.2;
+  k9 = 0.1;
+  k10 = 0;
+
+  array = malloc(length * sizeof(Register));
+
+  array[0].key = &k1;
+  array[1].key = &k2;
+  array[2].key = &k3;
+  array[3].key = &k4;
+  array[4].key = &k5;
+  array[5].key = &k6;
+  array[6].key = &k7;
+  array[7].key = &k8;
+  array[8].key = &k9;
+  array[9].key = &k10;
+  
+  bucket_sort(array, length, mul_plus_floor_double, compare_double);
+
+  ck_assert_double_eq(*((double *)array[0].key), 0);
+  ck_assert_double_eq(*((double *)array[1].key), 0.1);
+  ck_assert_double_eq(*((double *)array[2].key), 0.2);
+  ck_assert_double_eq(*((double *)array[3].key), 0.3);
+  ck_assert_double_eq(*((double *)array[4].key), 0.4);
+  ck_assert_double_eq(*((double *)array[5].key), 0.5);
+  ck_assert_double_eq(*((double *)array[6].key), 0.6);
+  ck_assert_double_eq(*((double *)array[7].key), 0.7);
+  ck_assert_double_eq(*((double *)array[8].key), 0.8);
+  ck_assert_double_eq(*((double *)array[9].key), 0.9);
+
+  free(array);
 }
 END_TEST
 
@@ -5973,6 +6570,19 @@ Suite *make_test_suite(void)
   tcase_add_test(tc_core, test_insertion_sort_dll_15);
   tcase_add_test(tc_core, test_insertion_sort_dll_16);
 
+  tcase_add_test(tc_core, test_bucket_sort_1);
+  tcase_add_test(tc_core, test_bucket_sort_2);
+  tcase_add_test(tc_core, test_bucket_sort_3);
+  tcase_add_test(tc_core, test_bucket_sort_4);
+  tcase_add_test(tc_core, test_bucket_sort_5);
+  tcase_add_test(tc_core, test_bucket_sort_6);
+  tcase_add_test(tc_core, test_bucket_sort_7);
+  tcase_add_test(tc_core, test_bucket_sort_8);
+  tcase_add_test(tc_core, test_bucket_sort_9);
+  tcase_add_test(tc_core, test_bucket_sort_10);
+  tcase_add_test(tc_core, test_bucket_sort_11);
+  tcase_add_test(tc_core, test_bucket_sort_12);
+  
   suite_add_tcase(s, tc_core);
 
   return s;

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -3511,6 +3511,305 @@ START_TEST(test_counting_sort_by_nth_digit_6)
 }
 END_TEST
 
+START_TEST(test_radix_sort_1)
+{
+  int *out;
+  int length = 6;
+  int max_decimal_place = 1;
+  int array[] = {5, 2, 4, 6, 1, 3};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 1);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 3);
+  ck_assert_int_eq(out[3], 4);
+  ck_assert_int_eq(out[4], 5);
+  ck_assert_int_eq(out[5], 6);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_2)
+{
+  int *out;
+  int length = 1;
+  int max_decimal_place = 1;
+  int array[] = {5};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 5);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_3)
+{
+  int *out;
+  int length = 11;
+  int max_decimal_place = 3;
+  int array[] = {10, 15, 5, 20, 50, 0, 100, 75, 30, 200, 2};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 5);
+  ck_assert_int_eq(out[3], 10);
+  ck_assert_int_eq(out[4], 15);
+  ck_assert_int_eq(out[5], 20);
+  ck_assert_int_eq(out[6], 30);
+  ck_assert_int_eq(out[7], 50);
+  ck_assert_int_eq(out[8], 75);
+  ck_assert_int_eq(out[9], 100);
+  ck_assert_int_eq(out[10], 200);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_4)
+{
+  int *out;
+  int length = 10;
+  int max_decimal_place = 1;
+  int array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 1);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+  ck_assert_int_eq(out[6], 6);
+  ck_assert_int_eq(out[7], 7);
+  ck_assert_int_eq(out[8], 8);
+  ck_assert_int_eq(out[9], 9);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_5)
+{
+  int *out;
+  int length = 10;
+  int max_decimal_place = 1;
+  int array[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 1);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+  ck_assert_int_eq(out[6], 6);
+  ck_assert_int_eq(out[7], 7);
+  ck_assert_int_eq(out[8], 8);
+  ck_assert_int_eq(out[9], 9);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_6)
+{
+  int *out;
+  int length = 6;
+  int max_decimal_place = 1;
+  int array[] = {2, 4, 5, 1, 2, 3, 7, 6};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 1);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_7)
+{
+  int *out;
+  int length = 14;
+  int max_decimal_place = 3;
+  int array[] = {0, 4, 2, 55, 300, 3, 700, 200, 100, 80, 7, 30, 150, 570};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 3);
+  ck_assert_int_eq(out[3], 4);
+  ck_assert_int_eq(out[4], 7);
+  ck_assert_int_eq(out[5], 30);
+  ck_assert_int_eq(out[6], 55);
+  ck_assert_int_eq(out[7], 80);
+  ck_assert_int_eq(out[8], 100);
+  ck_assert_int_eq(out[9], 150);
+  ck_assert_int_eq(out[10], 200);
+  ck_assert_int_eq(out[11], 300);
+  ck_assert_int_eq(out[12], 570);
+  ck_assert_int_eq(out[13], 700);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_8)
+{
+  int *out;
+  int length = 12;
+  int max_decimal_place = 3;
+  int array[] = {3, 15, 20, 30, 50, 75, 750, 500, 300, 200, 150, 10};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 3);
+  ck_assert_int_eq(out[1], 10);
+  ck_assert_int_eq(out[2], 15);
+  ck_assert_int_eq(out[3], 20);
+  ck_assert_int_eq(out[4], 30);
+  ck_assert_int_eq(out[5], 50);
+  ck_assert_int_eq(out[6], 75);
+  ck_assert_int_eq(out[7], 150);
+  ck_assert_int_eq(out[8], 200);
+  ck_assert_int_eq(out[9], 300);
+  ck_assert_int_eq(out[10], 500);
+  ck_assert_int_eq(out[11], 750);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_9)
+{
+  int *out;
+  int length = 6;
+  int max_decimal_place = 1;
+  int array[] = {5, 2, 4, 6, 1, 3};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 1);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 3);
+  ck_assert_int_eq(out[3], 4);
+  ck_assert_int_eq(out[4], 5);
+  ck_assert_int_eq(out[5], 6);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_10)
+{
+  int *out;
+  int length = 11;
+  int max_decimal_place = 3;
+  int array[] = {10, 15, 5, 20, 50, 0, 100, 75, 30, 200, 122};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 5);
+  ck_assert_int_eq(out[2], 10);
+  ck_assert_int_eq(out[3], 15);
+  ck_assert_int_eq(out[4], 20);
+  ck_assert_int_eq(out[5], 30);
+  ck_assert_int_eq(out[6], 50);
+  ck_assert_int_eq(out[7], 75);
+  ck_assert_int_eq(out[8], 100);
+  ck_assert_int_eq(out[9], 122);
+  ck_assert_int_eq(out[10], 200);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_11)
+{
+  int *out;
+  int length = 10;
+  int max_decimal_place = 1;
+  int array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 1);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+  ck_assert_int_eq(out[6], 6);
+  ck_assert_int_eq(out[7], 7);
+  ck_assert_int_eq(out[8], 8);
+  ck_assert_int_eq(out[9], 9);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_radix_sort_12)
+{
+  int *out;
+  int length = 10;
+  int max_decimal_place = 1;
+  int array[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+
+  out = malloc((length) * sizeof(int));
+
+  radix_sort(array, out, length, max_decimal_place);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 1);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+  ck_assert_int_eq(out[6], 6);
+  ck_assert_int_eq(out[7], 7);
+  ck_assert_int_eq(out[8], 8);
+  ck_assert_int_eq(out[9], 9);
+
+  free(out);
+}
+END_TEST
+
 Suite *make_test_suite(void)
 {
   Suite *s;
@@ -3706,6 +4005,19 @@ Suite *make_test_suite(void)
   tcase_add_test(tc_core, test_counting_sort_by_nth_digit_4);
   tcase_add_test(tc_core, test_counting_sort_by_nth_digit_5);
   tcase_add_test(tc_core, test_counting_sort_by_nth_digit_6);
+
+  tcase_add_test(tc_core, test_radix_sort_1);
+  tcase_add_test(tc_core, test_radix_sort_2);
+  tcase_add_test(tc_core, test_radix_sort_3);
+  tcase_add_test(tc_core, test_radix_sort_4);
+  tcase_add_test(tc_core, test_radix_sort_5);
+  tcase_add_test(tc_core, test_radix_sort_6);
+  tcase_add_test(tc_core, test_radix_sort_7);
+  tcase_add_test(tc_core, test_radix_sort_8);
+  tcase_add_test(tc_core, test_radix_sort_9);
+  tcase_add_test(tc_core, test_radix_sort_10);
+  tcase_add_test(tc_core, test_radix_sort_11);
+  tcase_add_test(tc_core, test_radix_sort_12);
 
   suite_add_tcase(s, tc_core);
 

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -2982,17 +2982,6 @@ END_TEST
 
 START_TEST(test_heap_sort_10)
 {
-  int array[] = {5};
-  int length = 1;
-
-  heap_sort(array, length);
-
-  ck_assert_int_eq(array[0], 5);
-}
-END_TEST
-
-START_TEST(test_heap_sort_11)
-{
   int array[] = {-10, 15, -5, -20, 50, 0, 100, 75, 30, 200, -200};
   int length = 11;
 
@@ -3012,7 +3001,7 @@ START_TEST(test_heap_sort_11)
 }
 END_TEST
 
-START_TEST(test_heap_sort_12)
+START_TEST(test_heap_sort_11)
 {
   int array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   int length = 10;
@@ -3032,7 +3021,7 @@ START_TEST(test_heap_sort_12)
 }
 END_TEST
 
-START_TEST(test_heap_sort_13)
+START_TEST(test_heap_sort_12)
 {
   int array[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
   int length = 10;
@@ -3051,6 +3040,355 @@ START_TEST(test_heap_sort_13)
   ck_assert_int_eq(array[9], 9);
 }
 END_TEST
+
+START_TEST(test_counting_sort_1)
+{
+  int *out;
+  int length = 6;
+  int upper_limit = 10;
+  int array[] = {5, 2, 4, 6, 1, 3};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 1);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 3);
+  ck_assert_int_eq(out[3], 4);
+  ck_assert_int_eq(out[4], 5);
+  ck_assert_int_eq(out[5], 6);
+
+  free(out);
+}
+END_TEST
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+START_TEST(test_counting_sort_2)
+{
+  int *out;
+  int length = 1;
+  int upper_limit = 10;
+  int array[] = {5};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 5);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_3)
+{
+  int *out;
+  int length = 11;
+  int upper_limit = 250;
+  int array[] = {10, 15, 5, 20, 50, 0, 100, 75, 30, 200, 2};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 5);
+  ck_assert_int_eq(out[3], 10);
+  ck_assert_int_eq(out[4], 15);
+  ck_assert_int_eq(out[5], 20);
+  ck_assert_int_eq(out[6], 30);
+  ck_assert_int_eq(out[7], 50);
+  ck_assert_int_eq(out[8], 75);
+  ck_assert_int_eq(out[9], 100);
+  ck_assert_int_eq(out[10], 200);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_4)
+{
+  int *out;
+  int length = 10;
+  int upper_limit = 250;
+  int array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 1);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+  ck_assert_int_eq(out[6], 6);
+  ck_assert_int_eq(out[7], 7);
+  ck_assert_int_eq(out[8], 8);
+  ck_assert_int_eq(out[9], 9);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_5)
+{
+  int *out;
+  int length = 10;
+  int upper_limit = 20;
+  int array[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 1);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+  ck_assert_int_eq(out[6], 6);
+  ck_assert_int_eq(out[7], 7);
+  ck_assert_int_eq(out[8], 8);
+  ck_assert_int_eq(out[9], 9);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_6)
+{
+  int *out;
+  int length = 6;
+  int upper_limit = 20;
+  int array[] = {2, 4, 5, 1, 2, 3, 7, 6};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 1);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_7)
+{
+  int *out;
+  int length = 14;
+  int upper_limit = 1000;
+  int array[] = {0, 4, 2, 55, 300, 3, 700, 200, 100, 80, 7, 30, 150, 570};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 3);
+  ck_assert_int_eq(out[3], 4);
+  ck_assert_int_eq(out[4], 7);
+  ck_assert_int_eq(out[5], 30);
+  ck_assert_int_eq(out[6], 55);
+  ck_assert_int_eq(out[7], 80);
+  ck_assert_int_eq(out[8], 100);
+  ck_assert_int_eq(out[9], 150);
+  ck_assert_int_eq(out[10], 200);
+  ck_assert_int_eq(out[11], 300);
+  ck_assert_int_eq(out[12], 570);
+  ck_assert_int_eq(out[13], 700);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_8)
+{
+  int *out;
+  int length = 12;
+  int upper_limit = 1000;
+  int array[] = {3, 15, 20, 30, 50, 75, 750, 500, 300, 200, 150, 10};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 3);
+  ck_assert_int_eq(out[1], 10);
+  ck_assert_int_eq(out[2], 15);
+  ck_assert_int_eq(out[3], 20);
+  ck_assert_int_eq(out[4], 30);
+  ck_assert_int_eq(out[5], 50);
+  ck_assert_int_eq(out[6], 75);
+  ck_assert_int_eq(out[7], 150);
+  ck_assert_int_eq(out[8], 200);
+  ck_assert_int_eq(out[9], 300);
+  ck_assert_int_eq(out[10], 500);
+  ck_assert_int_eq(out[11], 750);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_9)
+{
+  int *out;
+  int length = 6;
+  int upper_limit = 10;
+  int array[] = {5, 2, 4, 6, 1, 3};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 1);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 3);
+  ck_assert_int_eq(out[3], 4);
+  ck_assert_int_eq(out[4], 5);
+  ck_assert_int_eq(out[5], 6);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_10)
+{
+  int *out;
+  int length = 11;
+  int upper_limit = 200;
+  int array[] = {10, 15, 5, 20, 50, 0, 100, 75, 30, 200, 122};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 5);
+  ck_assert_int_eq(out[2], 10);
+  ck_assert_int_eq(out[3], 15);
+  ck_assert_int_eq(out[4], 20);
+  ck_assert_int_eq(out[5], 30);
+  ck_assert_int_eq(out[6], 50);
+  ck_assert_int_eq(out[7], 75);
+  ck_assert_int_eq(out[8], 100);
+  ck_assert_int_eq(out[9], 122);
+  ck_assert_int_eq(out[10], 200);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_11)
+{
+  int *out;
+  int length = 10;
+  int upper_limit = 200;
+  int array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 1);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+  ck_assert_int_eq(out[6], 6);
+  ck_assert_int_eq(out[7], 7);
+  ck_assert_int_eq(out[8], 8);
+  ck_assert_int_eq(out[9], 9);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_12)
+{
+  int *out;
+  int length = 10;
+  int upper_limit = 200;
+  int array[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort(array, out, length, upper_limit);
+
+  ck_assert_int_eq(out[0], 0);
+  ck_assert_int_eq(out[1], 1);
+  ck_assert_int_eq(out[2], 2);
+  ck_assert_int_eq(out[3], 3);
+  ck_assert_int_eq(out[4], 4);
+  ck_assert_int_eq(out[5], 5);
+  ck_assert_int_eq(out[6], 6);
+  ck_assert_int_eq(out[7], 7);
+  ck_assert_int_eq(out[8], 8);
+  ck_assert_int_eq(out[9], 9);
+
+  free(out);
+  }
+END_TEST
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 Suite *make_test_suite(void)
 {
@@ -3227,7 +3565,19 @@ Suite *make_test_suite(void)
   tcase_add_test(tc_core, test_heap_sort_10);
   tcase_add_test(tc_core, test_heap_sort_11);
   tcase_add_test(tc_core, test_heap_sort_12);
-  tcase_add_test(tc_core, test_heap_sort_13);
+
+  tcase_add_test(tc_core, test_counting_sort_1);
+  tcase_add_test(tc_core, test_counting_sort_2);
+  tcase_add_test(tc_core, test_counting_sort_3);
+  tcase_add_test(tc_core, test_counting_sort_4);
+  tcase_add_test(tc_core, test_counting_sort_5);
+  tcase_add_test(tc_core, test_counting_sort_6);
+  tcase_add_test(tc_core, test_counting_sort_7);
+  tcase_add_test(tc_core, test_counting_sort_8);
+  tcase_add_test(tc_core, test_counting_sort_9);
+  tcase_add_test(tc_core, test_counting_sort_10);
+  tcase_add_test(tc_core, test_counting_sort_11);
+  tcase_add_test(tc_core, test_counting_sort_12);
 
   suite_add_tcase(s, tc_core);
 

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -3063,35 +3063,6 @@ START_TEST(test_counting_sort_1)
 }
 END_TEST
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 START_TEST(test_counting_sort_2)
 {
   int *out;
@@ -3366,29 +3337,8 @@ START_TEST(test_counting_sort_12)
   ck_assert_int_eq(out[9], 9);
 
   free(out);
-  }
+}
 END_TEST
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 Suite *make_test_suite(void)
 {

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -3340,6 +3340,177 @@ START_TEST(test_counting_sort_12)
 }
 END_TEST
 
+START_TEST(test_counting_sort_by_nth_digit_1)
+{
+  int *out;
+  int n = 1;
+  int length = 9;
+  int array[] = {81, 56, 47, 19, 24, 62, 93, 35, 8};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort_by_nth_digit(array, out, length, n);
+
+  ck_assert_int_eq(out[0], 81);
+  ck_assert_int_eq(out[1], 62);
+  ck_assert_int_eq(out[2], 93);
+  ck_assert_int_eq(out[3], 24);
+  ck_assert_int_eq(out[4], 35);
+  ck_assert_int_eq(out[5], 56);
+  ck_assert_int_eq(out[6], 47);
+  ck_assert_int_eq(out[7], 8);
+  ck_assert_int_eq(out[8], 19);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_by_nth_digit_2)
+{
+  int *out;
+  int n = 2;
+  int length = 10;
+  int array[] = {160, 122, 128, 79, 77, 13, 99, 8, 26, 108};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort_by_nth_digit(array, out, length, n);
+
+  ck_assert_int_eq(out[0], 8);
+  ck_assert_int_eq(out[1], 108);
+  ck_assert_int_eq(out[2], 13);
+  ck_assert_int_eq(out[3], 122);
+  ck_assert_int_eq(out[4], 128);
+  ck_assert_int_eq(out[5], 26);
+  ck_assert_int_eq(out[6], 160);
+  ck_assert_int_eq(out[7], 79);
+  ck_assert_int_eq(out[8], 77);
+  ck_assert_int_eq(out[9], 99);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_by_nth_digit_3)
+{
+  int *out;
+  int n = 1;
+  int length = 8;
+  int array[] = {170, 45, 75, 90, 802, 24, 2, 66};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort_by_nth_digit(array, out, length, n);
+
+  ck_assert_int_eq(out[0], 170);
+  ck_assert_int_eq(out[1], 90);
+  ck_assert_int_eq(out[2], 802);
+  ck_assert_int_eq(out[3], 2);
+  ck_assert_int_eq(out[4], 24);
+  ck_assert_int_eq(out[5], 45);
+  ck_assert_int_eq(out[6], 75);
+  ck_assert_int_eq(out[7], 66);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_by_nth_digit_4)
+{
+  int *out;
+  int n = 2;
+  int length = 8;
+  int array[] = {170, 90, 802, 2, 24, 45, 75, 66};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort_by_nth_digit(array, out, length, n);
+
+  ck_assert_int_eq(out[0], 802);
+  ck_assert_int_eq(out[1], 2);
+  ck_assert_int_eq(out[2], 24);
+  ck_assert_int_eq(out[3], 45);
+  ck_assert_int_eq(out[4], 66);
+  ck_assert_int_eq(out[5], 170);
+  ck_assert_int_eq(out[6], 75);
+  ck_assert_int_eq(out[7], 90);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_by_nth_digit_5)
+{
+  int *out;
+  int n = 3;
+  int length = 8;
+  int array[] = {802, 2, 24, 45, 66, 170, 75, 90};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort_by_nth_digit(array, out, length, n);
+
+  ck_assert_int_eq(out[0], 2);
+  ck_assert_int_eq(out[1], 24);
+  ck_assert_int_eq(out[2], 45);
+  ck_assert_int_eq(out[3], 66);
+  ck_assert_int_eq(out[4], 75);
+  ck_assert_int_eq(out[5], 90);
+  ck_assert_int_eq(out[6], 170);
+  ck_assert_int_eq(out[7], 802);
+
+  free(out);
+}
+END_TEST
+
+START_TEST(test_counting_sort_by_nth_digit_6)
+{
+  int *out;
+  int n = 1;
+  int length = 30;
+  int array[] = {698, 506, 619, 179, 524, 714, 890, 41,  358, 656,
+                 336, 755, 990, 242, 133, 258, 564, 338, 274, 305,
+                 984, 220, 656, 307, 359, 836, 495, 426, 847, 387};
+
+  out = malloc((length) * sizeof(int));
+
+  counting_sort_by_nth_digit(array, out, length, n);
+
+  ck_assert_int_eq(out[0], 890);
+  ck_assert_int_eq(out[1], 990);
+  ck_assert_int_eq(out[2], 220);
+  ck_assert_int_eq(out[3], 41);
+  ck_assert_int_eq(out[4], 242);
+  ck_assert_int_eq(out[5], 133);
+  ck_assert_int_eq(out[6], 524);
+  ck_assert_int_eq(out[7], 714);
+  ck_assert_int_eq(out[8], 564);
+  ck_assert_int_eq(out[9], 274);
+  ck_assert_int_eq(out[10], 984);
+  ck_assert_int_eq(out[11], 755);
+  ck_assert_int_eq(out[12], 305);
+  ck_assert_int_eq(out[13], 495);
+  ck_assert_int_eq(out[14], 506);
+  ck_assert_int_eq(out[15], 656);
+  ck_assert_int_eq(out[16], 336);
+  ck_assert_int_eq(out[17], 656);
+  ck_assert_int_eq(out[18], 836);
+  ck_assert_int_eq(out[19], 426);
+  ck_assert_int_eq(out[20], 307);
+  ck_assert_int_eq(out[21], 847);
+  ck_assert_int_eq(out[22], 387);
+  ck_assert_int_eq(out[23], 698);
+  ck_assert_int_eq(out[24], 358);
+  ck_assert_int_eq(out[25], 258);
+  ck_assert_int_eq(out[26], 338);
+  ck_assert_int_eq(out[27], 619);
+  ck_assert_int_eq(out[28], 179);
+  ck_assert_int_eq(out[29], 359);
+
+  free(out);
+}
+END_TEST
+
 Suite *make_test_suite(void)
 {
   Suite *s;
@@ -3528,6 +3699,13 @@ Suite *make_test_suite(void)
   tcase_add_test(tc_core, test_counting_sort_10);
   tcase_add_test(tc_core, test_counting_sort_11);
   tcase_add_test(tc_core, test_counting_sort_12);
+
+  tcase_add_test(tc_core, test_counting_sort_by_nth_digit_1);
+  tcase_add_test(tc_core, test_counting_sort_by_nth_digit_2);
+  tcase_add_test(tc_core, test_counting_sort_by_nth_digit_3);
+  tcase_add_test(tc_core, test_counting_sort_by_nth_digit_4);
+  tcase_add_test(tc_core, test_counting_sort_by_nth_digit_5);
+  tcase_add_test(tc_core, test_counting_sort_by_nth_digit_6);
 
   suite_add_tcase(s, tc_core);
 

--- a/tests/test_stack.c
+++ b/tests/test_stack.c
@@ -4,21 +4,21 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-Stack *stk;
-Register *reg;
+Stack* stk;
+Register* reg;
 
 int i;
 
 void setup(void);
 void teardown(void);
-Suite *make_test_suite(void);
-int compare(void *key1, void *key2);
+Suite* make_test_suite(void);
+int compare(void* key1, void* key2);
 
-int compare(void *key1, void *key2)
+int compare(void* key1, void* key2)
 {
   int result;
-  int k1 = *((int *)key1);
-  int k2 = *((int *)key2);
+  int k1 = *((int*)key1);
+  int k2 = *((int*)key2);
 
   if (k1 > k2)
     {
@@ -178,7 +178,7 @@ START_TEST(test_stack_pop_2)
   ck_assert_int_eq(result2, true);
   ck_assert_int_eq(result3, false);
 
-  ck_assert_int_eq(*((int *)reg->key), 7);
+  ck_assert_int_eq(*((int*)reg->key), 7);
 }
 END_TEST
 
@@ -186,8 +186,8 @@ START_TEST(test_stack_pop_3)
 {
   int k1, k2;
   bool result1, result2, result3;
-  Register *el1;
-  Register *el2;
+  Register* el1;
+  Register* el2;
 
   k1 = 7;
   k2 = -5;
@@ -209,18 +209,18 @@ START_TEST(test_stack_pop_3)
   ck_assert_int_eq(result2, true);
   ck_assert_int_eq(result3, false);
 
-  ck_assert_int_eq(*((int *)el1->key), -5);
-  ck_assert_int_eq(*((int *)el2->key), 7);
+  ck_assert_int_eq(*((int*)el1->key), -5);
+  ck_assert_int_eq(*((int*)el2->key), 7);
 
   free(el1);
   free(el2);
 }
 END_TEST
 
-Suite *make_test_suite(void)
+Suite* make_test_suite(void)
 {
-  Suite *s;
-  TCase *tc_core;
+  Suite* s;
+  TCase* tc_core;
 
   s = suite_create("Stack Creation Test Suite");
 
@@ -253,7 +253,7 @@ Suite *make_test_suite(void)
 int main(void)
 {
   int number_failed;
-  SRunner *sr;
+  SRunner* sr;
 
   sr = srunner_create(make_test_suite());
   srunner_set_fork_status(sr, CK_NOFORK);

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -322,6 +322,267 @@ START_TEST(test_sample_5)
 }
 END_TEST
 
+START_TEST(test_ipow_1)
+{
+  int base, exp, result;
+
+  base = 3;
+  exp = 9;
+
+  result = ipow(base, exp);
+
+  ck_assert_int_eq(result, 19683);
+}
+END_TEST
+
+START_TEST(test_ipow_2)
+{
+  int base, exp, result;
+
+  base = 27;
+  exp = 0;
+
+  result = ipow(base, exp);
+
+  ck_assert_int_eq(result, 1);
+}
+END_TEST
+
+START_TEST(test_ipow_3)
+{
+  int base, exp, result;
+
+  base = 0;
+  exp = 0;
+
+  result = ipow(base, exp);
+
+  ck_assert_int_eq(result, 1);
+}
+END_TEST
+
+START_TEST(test_ipow_4)
+{
+  int base, exp, result;
+
+  base = 0;
+  exp = 10;
+
+  result = ipow(base, exp);
+
+  ck_assert_int_eq(result, 0);
+}
+END_TEST
+
+START_TEST(test_ipow_5)
+{
+  int base, exp, result;
+
+  base = 12;
+  exp = 4;
+
+  result = ipow(base, exp);
+
+  ck_assert_int_eq(result, 20736);
+}
+END_TEST
+
+START_TEST(test_nth_digit_1)
+{
+  int number, nth, base, value;
+
+  number = 19324;
+  nth = 1;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, 4);
+}
+END_TEST
+
+START_TEST(test_nth_digit_2)
+{
+  int number, nth, base, value;
+
+  number = 19324;
+  nth = 2;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, 2);
+}
+END_TEST
+
+START_TEST(test_nth_digit_3)
+{
+  int number, nth, base, value;
+
+  number = 19324;
+  nth = 3;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, 3);
+}
+END_TEST
+
+START_TEST(test_nth_digit_4)
+{
+  int number, nth, base, value;
+
+  number = 19324;
+  nth = 4;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, 9);
+}
+END_TEST
+
+START_TEST(test_nth_digit_5)
+{
+  int number, nth, base, value;
+
+  number = 19324;
+  nth = 5;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, 1);
+}
+END_TEST
+
+START_TEST(test_nth_digit_6)
+{
+  int number, nth, base, value;
+
+  number = 19324;
+  nth = 10;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, 0);
+}
+END_TEST
+
+START_TEST(test_nth_digit_7)
+{
+  int number, nth, base, value;
+
+  number = 19324;
+  nth = 7;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, 0);
+}
+END_TEST
+
+START_TEST(test_nth_digit_8)
+{
+  int number, nth, base, value;
+
+  number = -52918;
+  nth = 1;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, -8);
+}
+END_TEST
+
+START_TEST(test_nth_digit_9)
+{
+  int number, nth, base, value;
+
+  number = -52918;
+  nth = 2;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, -1);
+}
+END_TEST
+
+START_TEST(test_nth_digit_10)
+{
+  int number, nth, base, value;
+
+  number = -52918;
+  nth = 3;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, -9);
+}
+END_TEST
+
+START_TEST(test_nth_digit_11)
+{
+  int number, nth, base, value;
+
+  number = -52918;
+  nth = 4;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, -2);
+}
+END_TEST
+
+START_TEST(test_nth_digit_12)
+{
+  int number, nth, base, value;
+
+  number = -52918;
+  nth = 5;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, -5);
+}
+END_TEST
+
+START_TEST(test_nth_digit_13)
+{
+  int number, nth, base, value;
+
+  number = -52918;
+  nth = 10;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, 0);
+}
+END_TEST
+
+START_TEST(test_nth_digit_14)
+{
+  int number, nth, base, value;
+
+  number = -52918;
+  nth = 7;
+  base = 10;
+
+  value = nth_digit(number, nth, base);
+
+  ck_assert_int_eq(value, 0);
+}
+END_TEST
+
 Suite *make_test_suite(void)
 {
   Suite *s;
@@ -358,6 +619,27 @@ Suite *make_test_suite(void)
   tcase_add_test(tc_core, test_sample_3);
   tcase_add_test(tc_core, test_sample_4);
   tcase_add_test(tc_core, test_sample_5);
+
+  tcase_add_test(tc_core, test_ipow_1);
+  tcase_add_test(tc_core, test_ipow_2);
+  tcase_add_test(tc_core, test_ipow_3);
+  tcase_add_test(tc_core, test_ipow_4);
+  tcase_add_test(tc_core, test_ipow_5);
+
+  tcase_add_test(tc_core, test_nth_digit_1);
+  tcase_add_test(tc_core, test_nth_digit_2);
+  tcase_add_test(tc_core, test_nth_digit_3);
+  tcase_add_test(tc_core, test_nth_digit_4);
+  tcase_add_test(tc_core, test_nth_digit_5);
+  tcase_add_test(tc_core, test_nth_digit_6);
+  tcase_add_test(tc_core, test_nth_digit_7);
+  tcase_add_test(tc_core, test_nth_digit_8);
+  tcase_add_test(tc_core, test_nth_digit_9);
+  tcase_add_test(tc_core, test_nth_digit_10);
+  tcase_add_test(tc_core, test_nth_digit_11);
+  tcase_add_test(tc_core, test_nth_digit_12);
+  tcase_add_test(tc_core, test_nth_digit_13);
+  tcase_add_test(tc_core, test_nth_digit_14);
 
   suite_add_tcase(s, tc_core);
 

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <utils.h>
 
-Suite *make_test_suite(void);
+Suite* make_test_suite(void);
 
 START_TEST(test_swap_1)
 {
@@ -583,10 +583,10 @@ START_TEST(test_nth_digit_14)
 }
 END_TEST
 
-Suite *make_test_suite(void)
+Suite* make_test_suite(void)
 {
-  Suite *s;
-  TCase *tc_core;
+  Suite* s;
+  TCase* tc_core;
 
   s = suite_create("Utils Test Suite");
 
@@ -649,7 +649,7 @@ Suite *make_test_suite(void)
 int main(void)
 {
   int number_failed;
-  SRunner *sr;
+  SRunner* sr;
 
   sr = srunner_create(make_test_suite());
   srunner_set_fork_status(sr, CK_NOFORK);


### PR DESCRIPTION
# Add algorithms for sorting in linear time
 
## Description

Fixes #31 

* Add linkage to `lm` lib to gcc flags
* Configure clang-format to align pointer to the left.
* Add implementation / unit test / documentation for :
   + `counting sort`
   + `radix sort`
   + `bucket sort`
   + `counting sort`
   + counting sort based on nth digit (auxiliary function)
   + integer power (auxiliary function)
   + get nth digit  of number (auxiliary function)
   + insertion sort for doubly linked list (auxiliary function)
   + get nth element from doubly linked list (auxiliary function)
   + free nodes in doubly linked list (auxiliary function)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Add test cases for each new function

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules