### PR TITLE
Allow tests by build mode. Make CI debug mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
   - pkg-config --version
 script:
   - cd build
-  - cmake ..
+  - cmake D CMAKE_BUILD_TYPE=Debug ..
   - make
   - make test VERBOSE=1
   - cd .. && bash ./check_code_format.sh

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,35 +15,40 @@ include(CheckSymbolExists)
 include(CheckTypeSize)
 include(FindValgrind)
 
-file(GLOB test_src ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
-
-foreach(test_src_file ${test_src})
-
-    string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" test_name ${test_src_file})
-    string(REPLACE ".c" "" test_name ${test_name})
-    set(valgrind_test "valgrind_${test_name}") 
-
-    # Since Check uses Threads to paralelize the tests, it's mandatory
-    # add pthread as a dependency, alongside the Check libraries.
-    add_executable(${test_name} ${test_src_file})
-    target_link_libraries(${test_name} sibylline ${CHECK_LIBRARIES} pthread m)
-
-    # Create testing target and redirect its output to `Testing` folder
-    add_test(NAME ${test_name} COMMAND ${test_name} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Testing)
-    set_tests_properties(${test_name} PROPERTIES TIMEOUT 30) 
-
-endforeach(test_src_file ${test_src})
-
-foreach(test_src_file ${test_src})
-
-    string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" test_name ${test_src_file})
-    string(REPLACE ".c" "" test_name ${test_name})
-    set(valgrind_test "valgrind_${test_name}") 
-
-    # Aditional Valgrind test to check memory leaks in code
-    add_test(NAME ${valgrind_test}
-             COMMAND ${VALGRIND_PROGRAM} --leak-check=full
-             --error-exitcode=1 $<TARGET_FILE:${test_name}>)
-
-endforeach(test_src_file ${test_src})
-
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
+  file(GLOB test_src ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
+  
+  foreach(test_src_file ${test_src})
+  
+      string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" test_name ${test_src_file})
+      string(REPLACE ".c" "" test_name ${test_name})
+      set(valgrind_test "valgrind_${test_name}") 
+  
+      # Since Check uses Threads to paralelize the tests, it's mandatory
+      # add pthread as a dependency, alongside the Check libraries.
+      add_executable(${test_name} ${test_src_file})
+      target_link_libraries(${test_name} sibylline ${CHECK_LIBRARIES} pthread m)
+  
+      # Create testing target and redirect its output to `Testing` folder
+      add_test(NAME ${test_name} COMMAND ${test_name} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Testing)
+      set_tests_properties(${test_name} PROPERTIES TIMEOUT 30) 
+  
+  endforeach(test_src_file ${test_src})
+  
+  if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    
+    foreach(test_src_file ${test_src})
+    
+        string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" test_name ${test_src_file})
+        string(REPLACE ".c" "" test_name ${test_name})
+        set(valgrind_test "valgrind_${test_name}") 
+    
+        # Aditional Valgrind test to check memory leaks in code
+        add_test(NAME ${valgrind_test}
+                 COMMAND ${VALGRIND_PROGRAM} --leak-check=full
+                 --error-exitcode=1 $<TARGET_FILE:${test_name}>)
+    
+    endforeach(test_src_file ${test_src})
+    
+  endif()
+endif()

--- a/tests/test_max_pq.c
+++ b/tests/test_max_pq.c
@@ -928,6 +928,7 @@ START_TEST(test_heap_extract_max_1)
   int length = 9;
 
   array = malloc(length * sizeof(Register));
+  extracted = malloc(sizeof(Register));
   heap_size = malloc(sizeof(int));
 
   k1 = 50;
@@ -950,8 +951,6 @@ START_TEST(test_heap_extract_max_1)
   array[7].key = &k8;
   array[8].key = &k9;
 
-  heap_size = malloc(sizeof(int));
-  extracted = malloc(sizeof(Register));
   (*heap_size) = 0;
 
   result = heap_extract_max(array, heap_size, extracted, compare_int);


### PR DESCRIPTION
# Build tests according to build mode. Make CI debug mode

## Description
Edit CMake to build tests conditionally. Fix double pointer allocation.

Fixes #43 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules