### PR TITLE
Make formatting script path insensitive

### DIFF
--- a/format_code.sh
+++ b/format_code.sh
@@ -9,6 +9,8 @@
 # Requires Git and clang-format to be installed
 # sudo apt install clang-format
 
-clang-format -i ./src/include/*.h
-clang-format -i ./src/*.c
-clang-format -i ./tests/*.c
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+clang-format -i ${SCRIPT_DIR}/src/include/*.h
+clang-format -i ${SCRIPT_DIR}/src/*.c
+clang-format -i ${SCRIPT_DIR}/tests/*.c


### PR DESCRIPTION
## Description

Update formatting script `format_code.sh` so it can be executed from any path.

Fixes #50 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
