### PR TITLE
Ensure test dependencies are only used in Debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,26 @@ These instructions will get you a copy of the project up and running on your loc
 
 ## Installation
 
-To run this project the following programs need to be installed on your system:
-- Cmake
-- Check
+To build this library the following dependencies must be installed on your system:
+- [Cmake](https://cmake.org/)
+- [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
 
-Then, do as follows to build and test this library:
+Then, run the following commands to build this library:
 
 ```bash
 $ mkdir build && cd build
 $ cmake ..
 $ make
-$ make test
 ```
 
-### Build Type
+### Build Type and Tests
 
-By default `Release` build type will be used. Note that assert will be disabled with this build type.
+To run this lib's tests you need the following dependencies:
+- [Check](https://github.com/libcheck/check) (At least version 0.11.0)
+- [Valgrind](https://valgrind.org/)
 
-You can a specific build type vai the `CMAKE_BUILD_TYPE` flag.
+By default the `Release` build type will be used. Note that assertions will be disabled with this build type.
+You can specify a build type via the flag `CMAKE_BUILD_TYPE`.
 
 
 ```bash

--- a/cmake/FindValgrind.cmake
+++ b/cmake/FindValgrind.cmake
@@ -8,15 +8,20 @@
 # If you have valgrind installed in a non-standard place, you can define
 # VALGRIND_PREFIX to tell cmake where it is.
 
-message(STATUS "Valgrind Prefix: ${VALGRIND_PREFIX}")
+MESSAGE(STATUS "Valgrind Prefix: ${VALGRIND_PREFIX}")
 
-find_path(VALGRIND_INCLUDE_DIR valgrind/memcheck.h
+FIND_PATH(VALGRIND_INCLUDE_DIR valgrind/memcheck.h
   /usr/include /usr/local/include ${VALGRIND_PREFIX}/include)
-find_program(VALGRIND_PROGRAM NAMES valgrind PATH
+FIND_PROGRAM(VALGRIND_PROGRAM NAMES valgrind PATH
   /usr/bin /usr/local/bin ${VALGRIND_PREFIX}/bin)
 
 find_package_handle_standard_args(VALGRIND DEFAULT_MSG
     VALGRIND_INCLUDE_DIR
     VALGRIND_PROGRAM)
+
+IF(NOT VALGRIND_PROGRAM)
+  MESSAGE(FATAL_ERROR "Valgrind not found!")
+ENDIF(NOT VALGRIND_PROGRAM)
+
 
 mark_as_advanced(VALGRIND_INCLUDE_DIR VALGRIND_PROGRAM)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,39 +3,40 @@
 # may be: C:/Program Files/check
 # set(CHECK_INSTALL_DIR "C:/Program Files/check")
 
-find_package(Check REQUIRED)
 
-include(CheckCSourceCompiles)
-include(CheckCSourceRuns)
-include(CheckFunctionExists)
-include(CheckIncludeFile)
-include(CheckIncludeFiles)
-include(CheckLibraryExists)
-include(CheckSymbolExists)
-include(CheckTypeSize)
-include(FindValgrind)
 
-if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
-  file(GLOB test_src ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  # Only check for testing dependencies if in Debug mode 
+  find_package(Check REQUIRED)
+  find_package(Valgrind REQUIRED)
+  include(CheckCSourceCompiles)
+  include(CheckCSourceRuns)
+  include(CheckFunctionExists)
+  include(CheckIncludeFile)
+  include(CheckIncludeFiles)
+  include(CheckLibraryExists)
+  include(CheckSymbolExists)
+  include(CheckTypeSize)
   
-  foreach(test_src_file ${test_src})
-  
-      string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" test_name ${test_src_file})
-      string(REPLACE ".c" "" test_name ${test_name})
-      set(valgrind_test "valgrind_${test_name}") 
-  
-      # Since Check uses Threads to paralelize the tests, it's mandatory
-      # add pthread as a dependency, alongside the Check libraries.
-      add_executable(${test_name} ${test_src_file})
-      target_link_libraries(${test_name} sibylline ${CHECK_LIBRARIES} pthread m)
-  
-      # Create testing target and redirect its output to `Testing` folder
-      add_test(NAME ${test_name} COMMAND ${test_name} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Testing)
-      set_tests_properties(${test_name} PROPERTIES TIMEOUT 30) 
-  
-  endforeach(test_src_file ${test_src})
-  
-  if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
+    file(GLOB test_src ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
+    
+    foreach(test_src_file ${test_src})
+    
+        string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" test_name ${test_src_file})
+        string(REPLACE ".c" "" test_name ${test_name})
+        set(valgrind_test "valgrind_${test_name}") 
+    
+        # Since Check uses Threads to paralelize the tests, it's mandatory
+        # add pthread as a dependency, alongside the Check libraries.
+        add_executable(${test_name} ${test_src_file})
+        target_link_libraries(${test_name} sibylline ${CHECK_LIBRARIES} pthread m)
+    
+        # Create testing target and redirect its output to `Testing` folder
+        add_test(NAME ${test_name} COMMAND ${test_name} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Testing)
+        set_tests_properties(${test_name} PROPERTIES TIMEOUT 30) 
+    
+    endforeach(test_src_file ${test_src})
     
     foreach(test_src_file ${test_src})
     
@@ -49,6 +50,5 @@ if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" ST
                  --error-exitcode=1 $<TARGET_FILE:${test_name}>)
     
     endforeach(test_src_file ${test_src})
-    
   endif()
 endif()


### PR DESCRIPTION
# Pull Request Template

## Description

Test dependencies now are not needed to simply build the library unless it is in **Debug** mode. Builds in **Debug** mode are now interrupted if the Valgrind dependency is missing. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Run build in **Release** mode with no test dependencies installed
- [X] Run build in **Debug** mode without Check installed
- [X] Run build in **Debug** mode without Valgrind installed

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules