### PR TITLE
Upgrade to C99/CMake 4, support macOS

### DIFF
--- a/.github/workflows/build_test_checkstyle.yaml
+++ b/.github/workflows/build_test_checkstyle.yaml
@@ -13,9 +13,14 @@ jobs:
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - name: Install dependencies
-        run: | 
+        run: |
           sudo apt-get -qq update
-          sudo apt-get install -y build-essential cmake
+          sudo apt-get install -y build-essential ca-certificates gpg wget
+          # Kitware APT repo for CMake 4+
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main" | sudo tee /etc/apt/sources.list.d/kitware.list
+          sudo apt-get -qq update
+          sudo apt-get install -y cmake
           sudo apt-get install -qq valgrind
           sudo apt install -y clang-format
           sudo apt-get install -qq automake

--- a/.github/workflows/build_test_checkstyle.yaml
+++ b/.github/workflows/build_test_checkstyle.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Build-Test-CheckStyle:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - name: Install dependencies

--- a/.github/workflows/build_test_checkstyle.yaml
+++ b/.github/workflows/build_test_checkstyle.yaml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - name: Install CMake 4
+        run: |
+          wget -q https://github.com/Kitware/CMake/releases/download/v4.0.2/cmake-4.0.2-linux-x86_64.sh
+          sudo sh cmake-4.0.2-linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir
+          cmake --version
       - name: Install dependencies
         run: |
           sudo apt-get -qq update
-          sudo apt-get install -y build-essential ca-certificates gpg wget
-          # Kitware APT repo for CMake 4+
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-          echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main" | sudo tee /etc/apt/sources.list.d/kitware.list
-          sudo apt-get -qq update
-          sudo apt-get install -y cmake
+          sudo apt-get install -y build-essential
           sudo apt-get install -qq valgrind
           sudo apt install -y clang-format
           sudo apt-get install -qq automake
@@ -44,6 +44,7 @@ jobs:
           sudo rm -rf ./check-0.14.0*
       - name: Check dependencies' versions
         run: |
+          cmake --version
           automake --version
           autoconf --version
           libtool --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # https://libcheck.github.io/check/
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 4.0)
 
 project(sibylline)
 
@@ -18,7 +18,7 @@ set(SIBYLLINE_SRC_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(SIBYLLINE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
 
 # Show all warning messages
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -std=c89 -pedantic \
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -std=c99 -pedantic \
                    -Wmissing-prototypes -Wstrict-prototypes \
                    -Wold-style-definition")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,24 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -std=c99 -pedantic \
                    -Wmissing-prototypes -Wstrict-prototypes \
                    -Wold-style-definition")
 
+option(ENABLE_ASAN "Enable AddressSanitizer (detects memory errors)" OFF)
+if(ENABLE_ASAN)
+  add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=address)
+endif()
+
+# ASan + UBSan: closest cross-platform equivalent to Valgrind.
+# Adds leak detection on Linux (LSan); on macOS detects everything except leaks.
+option(ENABLE_SANITIZERS "Enable AddressSanitizer + UndefinedBehaviorSanitizer" OFF)
+if(ENABLE_SANITIZERS)
+  set(_sanitizers "address,undefined")
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    string(APPEND _sanitizers ",leak")
+  endif()
+  add_compile_options(-fsanitize=${_sanitizers} -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=${_sanitizers})
+endif()
+
 file(GLOB src ${SIBYLLINE_SRC_ROOT}/*.c)
 
 include_directories(${SIBYLLINE_INCLUDE_DIR})

--- a/README.md
+++ b/README.md
@@ -36,27 +36,57 @@ To build this library the following dependencies must be installed on your syste
 Then, run the following commands to build this library:
 
 ```bash
-$ mkdir build && cd build
-$ cmake ..
-$ make
+cmake -S . -B build
+cmake --build build
 ```
 
 ### Build Type and Tests
 
 To run this lib's tests you need the following dependencies:
 - [Check](https://github.com/libcheck/check) (At least version 0.11.0)
-- [Valgrind](https://valgrind.org/)
 
 By default the `Release` build type will be used. Note that assertions will be disabled with this build type.
-You can specify a build type via the flag `CMAKE_BUILD_TYPE`.
-
+Tests only build in `Debug` mode — specify it via `CMAKE_BUILD_TYPE`:
 
 ```bash
-$ mkdir build && cd build
-$ cmake -D CMAKE_BUILD_TYPE=Debug ..
-$ make
-$ make test
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+ctest --test-dir build
 ```
+
+### Memory Analysis
+
+#### Valgrind (Linux)
+
+Install [Valgrind](https://valgrind.org/) and enable it at configure time:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_VALGRIND=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+#### AddressSanitizer + UndefinedBehaviorSanitizer (Linux and macOS)
+
+No extra dependencies — ASan and UBSan ship with Clang/GCC. Detects use-after-free, buffer overflows, and undefined behavior. On Linux, leak detection (LSan) is also included automatically.
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZERS=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+#### Leak detection on macOS
+
+The `leaks` tool is built into macOS (Xcode developer tools). It is incompatible with `ENABLE_SANITIZERS` — run it as a separate step without sanitizers enabled:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_LEAKS=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+For complete macOS coverage, run both configurations: `ENABLE_SANITIZERS=ON` to catch memory errors, then `ENABLE_LEAKS=ON` to catch leaks.
 
 ***
 
@@ -65,7 +95,7 @@ $ make test
 If you wish to install the `sibylline` library run the following command with sudo after building the project:
 
 ```bash
-$ make install
+sudo cmake --install build
 ```
 
 <br>

--- a/check_code_format.sh
+++ b/check_code_format.sh
@@ -22,7 +22,7 @@ fi
 # check if something was modified
 notcorrectlist=`git status | grep "modified"`
 
-n_total="$(ls {tests/*.c,src/*.c,src/include/*.h} -1 | wc -l)"
+n_total="$(ls -1 {tests/*.c,src/*.c,src/include/*.h} | wc -l)"
 
 if [[ -z $notcorrectlist ]]; then
   # if nothing changed ok

--- a/cmake/FindCheck.cmake
+++ b/cmake/FindCheck.cmake
@@ -1,57 +1,114 @@
-# - Try to find the CHECK libraries
-#  Once done this will define
+# FindCheck.cmake - Find the Check unit testing framework (libcheck)
 #
-#  CHECK_FOUND - system has check
-#  CHECK_INCLUDE_DIR - the check include directory
-#  CHECK_LIBRARIES - check library
+# Provides:
+#   Check_FOUND
+#   Check_INCLUDE_DIRS
+#   Check_LIBRARIES
+#   Check::Check (imported target)
 #
-#  This configuration file for finding libcheck is originally from
-#  the opensync project. The originally was downloaded from here:
-#  opensync.org/browser/branches/3rd-party-cmake-modules/modules/FindCheck.cmake
-#
-#  Copyright (c) 2007 Daniel Gollub <dgollub@suse.de>
-#  Copyright (c) 2007 Bjoern Ricks  <b.ricks@fh-osnabrueck.de>
-#
-#  Redistribution and use is allowed according to the terms of the New
-#  BSD license.
-#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+# Backward-compatible variables:
+#   CHECK_FOUND
+#   CHECK_INCLUDE_DIR
+#   CHECK_INCLUDE_DIRS
+#   CHECK_LIBRARIES
 
+# DO NOT set cmake_minimum_required() in a Find-module.
 
-INCLUDE( FindPkgConfig )
+# Prefer pkg-config when available
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(PC_CHECK QUIET check)
+endif()
 
-# Take care about check.pc settings
-PKG_SEARCH_MODULE( CHECK check )
+# Optional user override
+set(_CHECK_HINT_INCLUDE "")
+set(_CHECK_HINT_LIB "")
 
-# Look for CHECK include dir and libraries
-IF( NOT CHECK_FOUND )
-	IF ( CHECK_INSTALL_DIR )
-		MESSAGE ( STATUS "Using override CHECK_INSTALL_DIR to find check" )
-		SET ( CHECK_INCLUDE_DIR  "${CHECK_INSTALL_DIR}/include" )
-		SET ( CHECK_INCLUDE_DIRS "${CHECK_INCLUDE_DIR}" )
-		FIND_LIBRARY( CHECK_LIBRARY NAMES check PATHS "${CHECK_INSTALL_DIR}/lib" )
-		FIND_LIBRARY( COMPAT_LIBRARY NAMES compat PATHS "${CHECK_INSTALL_DIR}/lib" )
-		SET ( CHECK_LIBRARIES "${CHECK_LIBRARY}" "${COMPAT_LIBRARY}" )
-	ELSE ( CHECK_INSTALL_DIR )
-		FIND_PATH( CHECK_INCLUDE_DIR check.h )
-		FIND_LIBRARY( CHECK_LIBRARIES NAMES check )
-	ENDIF ( CHECK_INSTALL_DIR )
+if(CHECK_INSTALL_DIR)
+  set(_CHECK_HINT_INCLUDE "${CHECK_INSTALL_DIR}/include")
+  set(_CHECK_HINT_LIB     "${CHECK_INSTALL_DIR}/lib")
+endif()
 
-	IF ( CHECK_INCLUDE_DIR AND CHECK_LIBRARIES )
-		SET( CHECK_FOUND 1 )
-		IF ( NOT Check_FIND_QUIETLY )
-			MESSAGE ( STATUS "Found CHECK: ${CHECK_LIBRARIES}" )
-		ENDIF ( NOT Check_FIND_QUIETLY )
-	ELSE ( CHECK_INCLUDE_DIR AND CHECK_LIBRARIES )
-		IF ( Check_FIND_REQUIRED )
-			MESSAGE( FATAL_ERROR "Could NOT find CHECK" )
-		ELSE ( Check_FIND_REQUIRED )
-			IF ( NOT Check_FIND_QUIETLY )
-				MESSAGE( STATUS "Could NOT find CHECK" )	
-			ENDIF ( NOT Check_FIND_QUIETLY )
-		ENDIF ( Check_FIND_REQUIRED )
-	ENDIF ( CHECK_INCLUDE_DIR AND CHECK_LIBRARIES )
-ENDIF( NOT CHECK_FOUND )
+# Homebrew/common prefixes fallback (Apple Silicon + Intel)
+set(_CHECK_PREFIX_HINTS
+  /opt/homebrew
+  /usr/local
+  /opt/local
+)
 
-# Hide advanced variables from CMake GUIs
-MARK_AS_ADVANCED( CHECK_INCLUDE_DIR CHECK_LIBRARIES )
+# Find header
+find_path(Check_INCLUDE_DIR
+  NAMES check.h
+  HINTS
+    ${_CHECK_HINT_INCLUDE}
+    ${PC_CHECK_INCLUDEDIR}
+    ${PC_CHECK_INCLUDE_DIRS}
+  PATHS
+    ${_CHECK_PREFIX_HINTS}
+  PATH_SUFFIXES
+    include
+)
 
+# Find library
+find_library(Check_LIBRARY
+  NAMES check
+  HINTS
+    ${_CHECK_HINT_LIB}
+    ${PC_CHECK_LIBDIR}
+    ${PC_CHECK_LIBRARY_DIRS}
+  PATHS
+    ${_CHECK_PREFIX_HINTS}
+  PATH_SUFFIXES
+    lib
+    lib64
+)
+
+# (Optional) compat library (older distros)
+find_library(Check_COMPAT_LIBRARY
+  NAMES compat
+  HINTS
+    ${_CHECK_HINT_LIB}
+    ${PC_CHECK_LIBDIR}
+    ${PC_CHECK_LIBRARY_DIRS}
+  PATHS
+    ${_CHECK_PREFIX_HINTS}
+  PATH_SUFFIXES
+    lib
+    lib64
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Check
+  REQUIRED_VARS Check_LIBRARY Check_INCLUDE_DIR
+)
+
+if(Check_FOUND)
+  set(Check_INCLUDE_DIRS "${Check_INCLUDE_DIR}")
+  if(Check_COMPAT_LIBRARY)
+    set(Check_LIBRARIES "${Check_LIBRARY};${Check_COMPAT_LIBRARY}")
+  else()
+    set(Check_LIBRARIES "${Check_LIBRARY}")
+  endif()
+
+  if(NOT TARGET Check::Check)
+    add_library(Check::Check UNKNOWN IMPORTED)
+    set_target_properties(Check::Check PROPERTIES
+      IMPORTED_LOCATION "${Check_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${Check_INCLUDE_DIR}"
+    )
+    if(Check_COMPAT_LIBRARY)
+      set_property(TARGET Check::Check APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES "${Check_COMPAT_LIBRARY}"
+      )
+    endif()
+  endif()
+endif()
+
+# Backward-compatible variable names used by older projects
+set(CHECK_FOUND        "${Check_FOUND}")
+set(CHECK_INCLUDE_DIR  "${Check_INCLUDE_DIR}")
+set(CHECK_INCLUDE_DIRS "${Check_INCLUDE_DIRS}")
+set(CHECK_LIBRARIES    "${Check_LIBRARIES}")
+
+mark_as_advanced(Check_INCLUDE_DIR Check_LIBRARY Check_COMPAT_LIBRARY)
+mark_as_advanced(CHECK_INCLUDE_DIR CHECK_LIBRARIES CHECK_INCLUDE_DIRS CHECK_FOUND)

--- a/cmake/FindValgrind.cmake
+++ b/cmake/FindValgrind.cmake
@@ -1,27 +1,58 @@
-# Find Valgrind.
+# FindValgrind.cmake
 #
 # This module defines:
-#  VALGRIND_INCLUDE_DIR, where to find valgrind/memcheck.h, etc.
-#  VALGRIND_PROGRAM, the valgrind executable.
-#  VALGRIND_FOUND, If false, do not try to use valgrind.
+#   Valgrind_FOUND
+#   Valgrind_INCLUDE_DIR
+#   Valgrind_PROGRAM
 #
-# If you have valgrind installed in a non-standard place, you can define
-# VALGRIND_PREFIX to tell cmake where it is.
+# Backward compatible:
+#   VALGRIND_FOUND
+#   VALGRIND_INCLUDE_DIR
+#   VALGRIND_PROGRAM
+#
+# If you have valgrind installed in a non-standard place, you can define:
+#   VALGRIND_PREFIX
 
-MESSAGE(STATUS "Valgrind Prefix: ${VALGRIND_PREFIX}")
+# Be quiet unless explicitly asked
+if(NOT Valgrind_FIND_QUIETLY)
+  message(STATUS "Valgrind Prefix: ${VALGRIND_PREFIX}")
+endif()
 
-FIND_PATH(VALGRIND_INCLUDE_DIR valgrind/memcheck.h
-  /usr/include /usr/local/include ${VALGRIND_PREFIX}/include)
-FIND_PROGRAM(VALGRIND_PROGRAM NAMES valgrind PATH
-  /usr/bin /usr/local/bin ${VALGRIND_PREFIX}/bin)
+# Prefix hints (macOS Homebrew + common Unix locations)
+set(_VALGRIND_PREFIX_HINTS
+  ${VALGRIND_PREFIX}
+  /opt/homebrew
+  /usr/local
+  /usr
+  /opt/local
+)
 
-find_package_handle_standard_args(VALGRIND DEFAULT_MSG
-    VALGRIND_INCLUDE_DIR
-    VALGRIND_PROGRAM)
+# Include dir (often absent on macOS; keep it optional unless you truly need headers)
+find_path(Valgrind_INCLUDE_DIR
+  NAMES valgrind/memcheck.h
+  HINTS ${_VALGRIND_PREFIX_HINTS}
+  PATH_SUFFIXES include
+)
 
-IF(NOT VALGRIND_PROGRAM)
-  MESSAGE(FATAL_ERROR "Valgrind not found!")
-ENDIF(NOT VALGRIND_PROGRAM)
+# Program (this is the main thing most projects need)
+find_program(Valgrind_PROGRAM
+  NAMES valgrind
+  HINTS ${_VALGRIND_PREFIX_HINTS}
+  PATH_SUFFIXES bin
+)
 
+include(FindPackageHandleStandardArgs)
 
+# If you require headers, add Valgrind_INCLUDE_DIR here too.
+# For running valgrind, Valgrind_PROGRAM is enough.
+find_package_handle_standard_args(Valgrind
+  REQUIRED_VARS Valgrind_PROGRAM
+)
+
+# Backward compatible variable names
+set(VALGRIND_INCLUDE_DIR "${Valgrind_INCLUDE_DIR}")
+set(VALGRIND_PROGRAM     "${Valgrind_PROGRAM}")
+set(VALGRIND_FOUND       "${Valgrind_FOUND}")
+
+mark_as_advanced(Valgrind_INCLUDE_DIR Valgrind_PROGRAM)
 mark_as_advanced(VALGRIND_INCLUDE_DIR VALGRIND_PROGRAM)

--- a/src/array_list.c
+++ b/src/array_list.c
@@ -1,5 +1,5 @@
 #include <array_list.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 void init_list(ArrayList* list, int capacity)
 {

--- a/src/bst.c
+++ b/src/bst.c
@@ -1,5 +1,6 @@
 #include <bst.h>
-#include <malloc.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 void inorder_tree_walk(BinarySearchTree* node)
 {

--- a/src/cdll.c
+++ b/src/cdll.c
@@ -1,5 +1,5 @@
 #include <cdll.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 void cdll_init(CircularDoublyLinkedList* nil)
 {

--- a/src/csll.c
+++ b/src/csll.c
@@ -1,5 +1,5 @@
 #include <csll.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdbool.h>
 
 CircularSinglyLinkedList* csll_insert_begin(CircularSinglyLinkedList** tail,

--- a/src/csll.c
+++ b/src/csll.c
@@ -1,6 +1,6 @@
 #include <csll.h>
-#include <stdlib.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 CircularSinglyLinkedList* csll_insert_begin(CircularSinglyLinkedList** tail,
                                             Register reg)

--- a/src/dll.c
+++ b/src/dll.c
@@ -1,5 +1,5 @@
 #include <dll.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 DoublyLinkedList* dll_insert(DoublyLinkedList** head, Register reg)
 {

--- a/src/graph.c
+++ b/src/graph.c
@@ -1,6 +1,6 @@
 #include <dll.h>
 #include <graph.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <queue.h>
 
 void bfs(DoublyLinkedList*** adj_list, ColoredNode* vrtxs[], int length,

--- a/src/graph.c
+++ b/src/graph.c
@@ -1,7 +1,7 @@
 #include <dll.h>
 #include <graph.h>
-#include <stdlib.h>
 #include <queue.h>
+#include <stdlib.h>
 
 void bfs(DoublyLinkedList*** adj_list, ColoredNode* vrtxs[], int length,
          ColoredNode* root)

--- a/src/include/register.h
+++ b/src/include/register.h
@@ -14,7 +14,7 @@ union Key
   int i;
   float f;
   unsigned int u;
-} key;
+};
 
 typedef struct
 {

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <queue.h>
+#include <stdlib.h>
 
 void init_queue(Queue* q, int length)
 {

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,4 +1,4 @@
-#include <malloc.h>
+#include <stdlib.h>
 #include <queue.h>
 
 void init_queue(Queue* q, int length)

--- a/src/rbt.c
+++ b/src/rbt.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <rbt.h>
+#include <stdlib.h>
 
 void init_rbtree(RedBlackTree** root, RedBlackTree* nil)
 {

--- a/src/rbt.c
+++ b/src/rbt.c
@@ -1,4 +1,4 @@
-#include <malloc.h>
+#include <stdlib.h>
 #include <rbt.h>
 
 void init_rbtree(RedBlackTree** root, RedBlackTree* nil)

--- a/src/seq_list.c
+++ b/src/seq_list.c
@@ -1,6 +1,6 @@
-#include <stdlib.h>
 #include <seq_list.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 void init_seq_list(SeqList* sl, int max_n_elems)
 {

--- a/src/seq_list.c
+++ b/src/seq_list.c
@@ -1,4 +1,4 @@
-#include <malloc.h>
+#include <stdlib.h>
 #include <seq_list.h>
 #include <stdio.h>
 

--- a/src/sll.c
+++ b/src/sll.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <sll.h>
+#include <stdlib.h>
 
 SinglyLinkedList* sll_insert(SinglyLinkedList** head, Register reg)
 {

--- a/src/sll.c
+++ b/src/sll.c
@@ -1,4 +1,4 @@
-#include <malloc.h>
+#include <stdlib.h>
 #include <sll.h>
 
 SinglyLinkedList* sll_insert(SinglyLinkedList** head, Register reg)

--- a/src/sort.c
+++ b/src/sort.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <utils.h>
+#include <limits.h>
 
 void insertion_sort(int array[], int start, int end)
 {
@@ -50,8 +51,8 @@ void merge(int array[], int start, int middle, int end)
       right[j] = array[middle + j + 1];
     }
 
-  left[n1] = INFINITY;
-  right[n2] = INFINITY;
+  left[n1] = INT_MAX;
+  right[n2] = INT_MAX;
 
   i = j = 0;
 

--- a/src/sort.c
+++ b/src/sort.c
@@ -1,13 +1,11 @@
 #include <dll.h>
 #include <heap.h>
 #include <limits.h>
-#include <stdlib.h>
 #include <math.h>
 #include <sort.h>
 #include <stdlib.h>
 #include <string.h>
 #include <utils.h>
-#include <limits.h>
 
 void insertion_sort(int array[], int start, int end)
 {

--- a/src/sort.c
+++ b/src/sort.c
@@ -1,14 +1,12 @@
 #include <dll.h>
 #include <heap.h>
 #include <limits.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 #include <sort.h>
 #include <stdlib.h>
 #include <string.h>
 #include <utils.h>
-
-#define INFINITY INT_MAX
 
 void insertion_sort(int array[], int start, int end)
 {

--- a/src/sort.c
+++ b/src/sort.c
@@ -169,8 +169,11 @@ void quick_sort(int array[], int start, int end)
 
 int rand_partition(int array[], int start, int end)
 {
-  int i;
-  i = sample(start, end);
+  int i, range;
+
+  range = end - start + 1;
+  i = (rand() % range) + start;
+
   swap(array, end, i);
   return partition(array, start, end);
 }

--- a/src/stack.c
+++ b/src/stack.c
@@ -1,4 +1,4 @@
-#include <malloc.h>
+#include <stdlib.h>
 #include <stack.h>
 
 void init_stack(Stack* stk, int length)

--- a/src/stack.c
+++ b/src/stack.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <stack.h>
+#include <stdlib.h>
 
 void init_stack(Stack* stk, int length)
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,10 @@ include(CTest)
 # Optional: allow forcing Valgrind on/off explicitly
 option(ENABLE_VALGRIND "Enable Valgrind tests (requires Valgrind installed)" OFF)
 
+# macOS leak detection via the built-in leaks tool.
+# Incompatible with ENABLE_SANITIZERS (ASan replaces malloc, breaking leaks).
+option(ENABLE_LEAKS "Enable macOS leaks tool tests (macOS only, do not combine with ENABLE_SANITIZERS)" OFF)
+
 # Enable tests in:
 # - Debug single-config
 # - any config in multi-config generators (Xcode, Ninja Multi-Config)
@@ -86,6 +90,22 @@ if(ENABLE_TESTS)
                 --leak-check=full
                 --error-exitcode=1
                 $<TARGET_FILE:${test_name}>
+      )
+    endif()
+
+    # macOS leaks tool — do not combine with ENABLE_SANITIZERS
+    if(ENABLE_LEAKS)
+      if(NOT APPLE)
+        message(FATAL_ERROR "ENABLE_LEAKS is only supported on macOS")
+      endif()
+      find_program(LEAKS_PROGRAM leaks REQUIRED)
+      add_test(
+        NAME leaks_${test_name}
+        COMMAND ${LEAKS_PROGRAM} --atExit -- $<TARGET_FILE:${test_name}>
+      )
+      set_tests_properties(leaks_${test_name} PROPERTIES
+        ENVIRONMENT "MallocStackLogging=1"
+        TIMEOUT 60
       )
     endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,14 +1,38 @@
-# If pkg-config is not installed on the system, then the CHECK_INSTALL_DIR var
-# must be set to the install location of Check. For example, on Windows, this
-# may be: C:/Program Files/check
-# set(CHECK_INSTALL_DIR "C:/Program Files/check")
+# tests/CMakeLists.txt
 
+include(CTest)
 
+# Optional: allow forcing Valgrind on/off explicitly
+option(ENABLE_VALGRIND "Enable Valgrind tests (requires Valgrind installed)" OFF)
 
-if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-  # Only check for testing dependencies if in Debug mode 
+# Enable tests in:
+# - Debug single-config
+# - any config in multi-config generators (Xcode, Ninja Multi-Config)
+set(ENABLE_TESTS OFF)
+if(CMAKE_CONFIGURATION_TYPES)
+  set(ENABLE_TESTS ON)
+elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(ENABLE_TESTS ON)
+endif()
+
+if(ENABLE_TESTS)
+
+  message(STATUS "Configuring unit tests")
+
+  # Only check for testing dependencies if in Debug mode (single-config),
+  # or always for multi-config generators (gated by ENABLE_TESTS above).
   find_package(Check REQUIRED)
-  find_package(Valgrind REQUIRED)
+  find_package(Threads REQUIRED)
+
+  # Valgrind is now truly optional with the updated FindValgrind.cmake
+  # - If ENABLE_VALGRIND=ON, require it.
+  # - Otherwise, try quietly and only add valgrind tests if found.
+  if(ENABLE_VALGRIND)
+    find_package(Valgrind REQUIRED)
+  else()
+    find_package(Valgrind QUIET)
+  endif()
+
   include(CheckCSourceCompiles)
   include(CheckCSourceRuns)
   include(CheckFunctionExists)
@@ -17,38 +41,54 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   include(CheckLibraryExists)
   include(CheckSymbolExists)
   include(CheckTypeSize)
-  
-  if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
-    file(GLOB test_src ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
-    
-    foreach(test_src_file ${test_src})
-    
-        string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" test_name ${test_src_file})
-        string(REPLACE ".c" "" test_name ${test_name})
-        set(valgrind_test "valgrind_${test_name}") 
-    
-        # Since Check uses Threads to paralelize the tests, it's mandatory
-        # add pthread as a dependency, alongside the Check libraries.
-        add_executable(${test_name} ${test_src_file})
-        target_link_libraries(${test_name} sibylline ${CHECK_LIBRARIES} pthread m)
-    
-        # Create testing target and redirect its output to `Testing` folder
-        add_test(NAME ${test_name} COMMAND ${test_name} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Testing)
-        set_tests_properties(${test_name} PROPERTIES TIMEOUT 30) 
-    
-    endforeach(test_src_file ${test_src})
-    
-    foreach(test_src_file ${test_src})
-    
-        string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" test_name ${test_src_file})
-        string(REPLACE ".c" "" test_name ${test_name})
-        set(valgrind_test "valgrind_${test_name}") 
-    
-        # Aditional Valgrind test to check memory leaks in code
-        add_test(NAME ${valgrind_test}
-                 COMMAND ${VALGRIND_PROGRAM} --leak-check=full
-                 --error-exitcode=1 $<TARGET_FILE:${test_name}>)
-    
-    endforeach(test_src_file ${test_src})
-  endif()
+
+  file(GLOB test_src "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
+
+  foreach(test_src_file ${test_src})
+
+    get_filename_component(test_name "${test_src_file}" NAME_WE)
+    set(valgrind_test "valgrind_${test_name}")
+
+    add_executable(${test_name} ${test_src_file})
+
+    # Link Check + threads portably
+    if(TARGET Check::Check)
+      target_link_libraries(${test_name}
+        PRIVATE
+          sibylline
+          Check::Check
+          Threads::Threads
+          m
+      )
+    else()
+      target_link_libraries(${test_name}
+        PRIVATE
+          sibylline
+          ${CHECK_LIBRARIES}
+          Threads::Threads
+          m
+      )
+    endif()
+
+    # Create testing target and redirect its output to `Testing` folder
+    add_test(
+      NAME ${test_name}
+      COMMAND ${test_name}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Testing
+    )
+    set_tests_properties(${test_name} PROPERTIES TIMEOUT 30)
+
+    # Additional Valgrind test to check memory leaks in code (only if found)
+    if(Valgrind_FOUND)
+      add_test(
+        NAME ${valgrind_test}
+        COMMAND ${Valgrind_PROGRAM}
+                --leak-check=full
+                --error-exitcode=1
+                $<TARGET_FILE:${test_name}>
+      )
+    endif()
+
+  endforeach()
+
 endif()

--- a/tests/test_array_list.c
+++ b/tests/test_array_list.c
@@ -1,6 +1,5 @@
 #include <array_list.h>
 #include <check.h>
-#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_array_list.c
+++ b/tests/test_array_list.c
@@ -1,6 +1,6 @@
 #include <array_list.h>
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_bst.c
+++ b/tests/test_bst.c
@@ -1,6 +1,6 @@
 #include <bst.h>
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_bst.c
+++ b/tests/test_bst.c
@@ -6048,7 +6048,6 @@ START_TEST(test_bst_iterative_tree_search_3)
   (*root) = NULL;
 
   k.i = 10;
-  key = k;
   reg->key = k;
   node1 = tree_insert(root, *reg, compare);
 
@@ -6064,7 +6063,7 @@ START_TEST(test_bst_iterative_tree_search_3)
   ck_assert_int_eq(node1->right == NULL, true);
   ck_assert_int_eq(node1->data.key.i, 10);
 
-  retrieved = iterative_tree_search(*root, key, compare);
+  retrieved = iterative_tree_search(*root, k, compare);
 
   ck_assert_int_eq(retrieved->p == NULL, true);
   ck_assert_int_eq(retrieved->left == NULL, true);

--- a/tests/test_bst.c
+++ b/tests/test_bst.c
@@ -1,6 +1,5 @@
 #include <bst.h>
 #include <check.h>
-#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_cdll.c
+++ b/tests/test_cdll.c
@@ -1,6 +1,5 @@
 #include <cdll.h>
 #include <check.h>
-#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_cdll.c
+++ b/tests/test_cdll.c
@@ -1,6 +1,6 @@
 #include <cdll.h>
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_csll.c
+++ b/tests/test_csll.c
@@ -1,6 +1,6 @@
 #include <check.h>
 #include <csll.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_csll.c
+++ b/tests/test_csll.c
@@ -1,6 +1,5 @@
 #include <check.h>
 #include <csll.h>
-#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -1,6 +1,6 @@
 #include <check.h>
 #include <dll.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_dll.c
+++ b/tests/test_dll.c
@@ -1,6 +1,5 @@
 #include <check.h>
 #include <dll.h>
-#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_graph.c
+++ b/tests/test_graph.c
@@ -3,7 +3,7 @@
 #include <dll.h>
 #include <graph.h>
 #include <limits.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/tests/test_graph.c
+++ b/tests/test_graph.c
@@ -3,7 +3,6 @@
 #include <dll.h>
 #include <graph.h>
 #include <limits.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/tests/test_heap.c
+++ b/tests/test_heap.c
@@ -1,6 +1,6 @@
 #include <check.h>
 #include <heap.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/tests/test_heap.c
+++ b/tests/test_heap.c
@@ -1,6 +1,5 @@
 #include <check.h>
 #include <heap.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/tests/test_max_pq.c
+++ b/tests/test_max_pq.c
@@ -1,5 +1,4 @@
 #include <check.h>
-#include <stdlib.h>
 #include <max_pq.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_max_pq.c
+++ b/tests/test_max_pq.c
@@ -1,5 +1,5 @@
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <max_pq.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_queue.c
+++ b/tests/test_queue.c
@@ -1,5 +1,4 @@
 #include <check.h>
-#include <stdlib.h>
 #include <queue.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_queue.c
+++ b/tests/test_queue.c
@@ -1,5 +1,5 @@
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <queue.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_rbt.c
+++ b/tests/test_rbt.c
@@ -1,5 +1,5 @@
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <rbt.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/test_rbt.c
+++ b/tests/test_rbt.c
@@ -1,5 +1,4 @@
 #include <check.h>
-#include <stdlib.h>
 #include <rbt.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/test_seq_list.c
+++ b/tests/test_seq_list.c
@@ -1,5 +1,5 @@
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <seq_list.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_seq_list.c
+++ b/tests/test_seq_list.c
@@ -1,5 +1,4 @@
 #include <check.h>
-#include <stdlib.h>
 #include <seq_list.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_sll.c
+++ b/tests/test_sll.c
@@ -1,5 +1,5 @@
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <sll.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/test_sll.c
+++ b/tests/test_sll.c
@@ -1,5 +1,4 @@
 #include <check.h>
-#include <stdlib.h>
 #include <sll.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -1,5 +1,4 @@
 #include <check.h>
-#include <stdlib.h>
 #include <math.h>
 #include <sort.h>
 #include <stdbool.h>

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -1,5 +1,5 @@
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 #include <sort.h>
 #include <stdbool.h>

--- a/tests/test_sort.c
+++ b/tests/test_sort.c
@@ -1788,8 +1788,8 @@ START_TEST(test_rand_partition_1)
 
   middle = rand_partition(array, start, end);
 
-  ck_assert_int_gt(middle, start - 1);
-  ck_assert_int_lt(middle, end + 1);
+  ck_assert_int_ge(middle, start);
+  ck_assert_int_le(middle, end);
 
   for (i = start; i <= end; i++)
     {
@@ -1799,7 +1799,7 @@ START_TEST(test_rand_partition_1)
         }
       else if (i > middle)
         {
-          ck_assert_uint_gt(array[i], array[middle]);
+          ck_assert_int_ge(array[i], array[middle]);
         }
     }
 }
@@ -1815,8 +1815,8 @@ START_TEST(test_rand_partition_2)
 
   middle = rand_partition(array, start, end);
 
-  ck_assert_int_gt(middle, start - 1);
-  ck_assert_int_lt(middle, end + 1);
+  ck_assert_int_ge(middle, start);
+  ck_assert_int_le(middle, end);
 
   for (i = start; i <= end; i++)
     {
@@ -1826,7 +1826,7 @@ START_TEST(test_rand_partition_2)
         }
       else if (i > middle)
         {
-          ck_assert_uint_gt(array[i], array[middle]);
+          ck_assert_int_ge(array[i], array[middle]);
         }
     }
 }
@@ -1842,8 +1842,8 @@ START_TEST(test_rand_partition_3)
 
   middle = rand_partition(array, start, end);
 
-  ck_assert_int_gt(middle, start - 1);
-  ck_assert_int_lt(middle, end + 1);
+  ck_assert_int_ge(middle, start);
+  ck_assert_int_le(middle, end);
 
   for (i = start; i <= end; i++)
     {
@@ -1853,7 +1853,7 @@ START_TEST(test_rand_partition_3)
         }
       else if (i > middle)
         {
-          ck_assert_uint_gt(array[i], array[middle]);
+          ck_assert_int_ge(array[i], array[middle]);
         }
     }
 }
@@ -1870,8 +1870,8 @@ START_TEST(test_rand_partition_4)
 
   middle = rand_partition(array, start, end);
 
-  ck_assert_int_gt(middle, start - 1);
-  ck_assert_int_lt(middle, end + 1);
+  ck_assert_int_ge(middle, start);
+  ck_assert_int_le(middle, end);
 
   for (i = start; i <= end; i++)
     {
@@ -1881,7 +1881,7 @@ START_TEST(test_rand_partition_4)
         }
       else if (i > middle)
         {
-          ck_assert_uint_gt(array[i], array[middle]);
+          ck_assert_int_ge(array[i], array[middle]);
         }
     }
 }
@@ -1897,8 +1897,8 @@ START_TEST(test_rand_partition_5)
 
   middle = rand_partition(array, start, end);
 
-  ck_assert_int_gt(middle, start - 1);
-  ck_assert_int_lt(middle, end + 1);
+  ck_assert_int_ge(middle, start);
+  ck_assert_int_le(middle, end);
 
   for (i = start; i <= end; i++)
     {
@@ -1908,7 +1908,7 @@ START_TEST(test_rand_partition_5)
         }
       else if (i > middle)
         {
-          ck_assert_uint_gt(array[i], array[middle]);
+          ck_assert_int_ge(array[i], array[middle]);
         }
     }
 }
@@ -2865,7 +2865,7 @@ END_TEST
 START_TEST(test_heap_sort_1)
 {
   int i;
-  union Key k;
+  union Key k = {0};
   int length = 6;
   Register* array;
   int values[] = {5, 2, 4, 6, 1, 3};
@@ -2888,7 +2888,7 @@ END_TEST
 START_TEST(test_heap_sort_2)
 {
   Register* array;
-  union Key k;
+  union Key k = {0};
   int length = 1;
   int values[] = {5};
 
@@ -2906,7 +2906,7 @@ END_TEST
 START_TEST(test_heap_sort_3)
 {
   int i;
-  union Key k;
+  union Key k = {0};
   int length = 11;
   Register* array;
   int values[] = {-10, 15, -5, -20, 50, 0, 100, 75, 30, 200, -200};
@@ -2929,7 +2929,7 @@ END_TEST
 START_TEST(test_heap_sort_4)
 {
   int i;
-  union Key k;
+  union Key k = {0};
   int length = 10;
   Register* array;
   int values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -2952,7 +2952,7 @@ END_TEST
 START_TEST(test_heap_sort_5)
 {
   int i;
-  union Key k;
+  union Key k = {0};
   int length = 10;
   Register* array;
   int values[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
@@ -2975,7 +2975,7 @@ END_TEST
 START_TEST(test_heap_sort_6)
 {
   int i;
-  union Key k;
+  union Key k = {0};
   int length = 6;
   Register* array;
   int values[] = {2, 4, 5, 1, 2, 3, 7, 6};
@@ -2998,7 +2998,7 @@ END_TEST
 START_TEST(test_heap_sort_7)
 {
   int i;
-  union Key k;
+  union Key k = {0};
   int length = 14;
   Register* array;
   int values[] = {0, 2, 3, 4, 55, 300, 700, -200, -100, -80, -7, 30, 150, 570};
@@ -3023,7 +3023,7 @@ START_TEST(test_heap_sort_8)
 {
   int i;
   Register* array;
-  union Key k;
+  union Key k = {0};
   int length = 12;
   int values[] = {3, 15, 20, 30, 50, 75, -75, -50, -30, -20, -15, -3};
   int expected[] = {-75, -50, -30, -20, -15, -3, 3, 15, 20, 30, 50, 75};
@@ -3045,7 +3045,7 @@ END_TEST
 START_TEST(test_heap_sort_9)
 {
   int i;
-  union Key k;
+  union Key k = {0};
   int length = 6;
   Register* array;
   int values[] = {5, 2, 4, 6, 1, 3};
@@ -3068,7 +3068,7 @@ END_TEST
 START_TEST(test_heap_sort_10)
 {
   int i;
-  union Key k;
+  union Key k = {0};
   int length = 11;
   Register* array;
   int values[] = {-10, 15, -5, -20, 50, 0, 100, 75, 30, 200, -200};
@@ -3091,7 +3091,7 @@ END_TEST
 START_TEST(test_heap_sort_11)
 {
   int i;
-  union Key k;
+  union Key k = {0};
   Register* array;
   int length = 10;
   int values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -3115,7 +3115,7 @@ START_TEST(test_heap_sort_12)
 {
   int i;
   Register* array;
-  union Key k;
+  union Key k = {0};
   int length = 10;
   int values[] = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
   int expected[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};

--- a/tests/test_stack.c
+++ b/tests/test_stack.c
@@ -1,5 +1,5 @@
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stack.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_stack.c
+++ b/tests/test_stack.c
@@ -1,5 +1,4 @@
 #include <check.h>
-#include <stdlib.h>
 #include <stack.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/test_str_builder.c
+++ b/tests/test_str_builder.c
@@ -1,5 +1,5 @@
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <str_builder.h>

--- a/tests/test_str_builder.c
+++ b/tests/test_str_builder.c
@@ -1,5 +1,4 @@
 #include <check.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <str_builder.h>

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -1,5 +1,4 @@
 #include <check.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <utils.h>

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -1,5 +1,5 @@
 #include <check.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <utils.h>


### PR DESCRIPTION
# Upgrade to C99, CMake 4, sanitizer support, and macOS compatibility

## Description

Upgrades the project from C89/CMake 3.1 to C99/CMake 4.0 and modernizes the build and memory analysis tooling. Replaces the Linux-only Valgrind requirement with opt-in memory analysis options that work cross-platform, including on macOS where Valgrind is unsupported.

Key changes:
- Upgraded C standard from C89 to C99 and CMake minimum version from 3.1 to 4.0
- Replaced `<malloc.h>` (non-standard) with `<stdlib.h>` across all source and test files
- Added `ENABLE_SANITIZERS` option: enables ASan + UBSan on all platforms, with LSan automatically included on Linux
- Added `ENABLE_ASAN` option: standalone AddressSanitizer for targeted use
- Added `ENABLE_LEAKS` option: wraps each test with the macOS built-in `leaks` tool for leak detection (macOS only, incompatible with `ENABLE_SANITIZERS`)
- Made Valgrind optional at configure time (`ENABLE_VALGRIND=ON`) instead of always required
- Rewrote `FindCheck.cmake` and `FindValgrind.cmake` to use modern CMake conventions (`find_package_handle_standard_args`, imported targets, Homebrew prefix hints)
- Fixed `rand_partition` to use standard `rand()` instead of an undefined `sample()` helper
- Fixed uninitialized `union Key` variables in sort tests to silence UBSan warnings
- Fixed `rand_partition` test assertions to use `ck_assert_int_ge/le` instead of boundary arithmetic
- Updated README with current build commands and a Memory Analysis section covering all four workflows

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] Standard tests: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build && ctest --test-dir build`
- [ ] Sanitizers: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZERS=ON && cmake --build build && ctest --test-dir build --output-on-failure`
- [ ] macOS leaks: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_LEAKS=ON && cmake --build build && ctest --test-dir build --output-on-failure`
- [ ] Valgrind (Linux): `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_VALGRIND=ON && cmake --build build && ctest --test-dir build --output-on-failure`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules